### PR TITLE
Fix explorer minerfee appearance

### DIFF
--- a/doc/examples/offline_transaction/offline_transaction.go
+++ b/doc/examples/offline_transaction/offline_transaction.go
@@ -232,12 +232,12 @@ func NewWallet(seed modules.Seed) *MyWallet {
 // SyncWallet syncs the wallet with the chain
 func (w *MyWallet) SyncWallet() error {
 	wg := sync.WaitGroup{}
-	// TODO: Enable this once miner transactions can be spent
 	// First get the current block height
-	// height, err := GetCurrentChainHeight()
-	// if err != nil {
-	// 	return err
-	// }
+	height, err := GetCurrentChainHeight()
+	if err != nil {
+		return err
+	}
+	fmt.Println("Chain is currently at height: ", height)
 	for address := range w.keys {
 		wg.Add(1)
 		go func(addr types.UnlockHash) {
@@ -253,25 +253,24 @@ func (w *MyWallet) SyncWallet() error {
 				panic("Address is not recognized as an unlock hash")
 			}
 			// We scann the blocks here for the miner fees, and the transactions for actual transations
-			// TODO: Enable this once miner transactions can be spent
-			// for _, block := range resp.Blocks {
-			// 	// Collect the miner fees
-			// 	// But only those that have matured already
-			// 	if block.Height+minerPayoutMaturityWindow >= height {
-			// 		fmt.Println("Ignoring miner payout that hasn't matured yet")
-			// 		continue
-			// 	}
-			// 	for i, minerPayout := range block.RawBlock.MinerPayouts {
-			// 		if minerPayout.UnlockHash == addr {
-			// 			fmt.Println("Found miner output with value ", minerPayout.Value)
-			// 			fmt.Println("Block: ", block.Height)
-			// 			for _, c := range block.MinerPayoutIDs {
-			// 				fmt.Println("Adding miner payout id", c.String())
-			// 			}
-			// 			w.unspentCoinOutputs[block.MinerPayoutIDs[i]] = minerPayout
-			// 		}
-			// 	}
-			// }
+			for _, block := range resp.Blocks {
+				// Collect the miner fees
+				// But only those that have matured already
+				if block.Height+minerPayoutMaturityWindow >= height {
+					fmt.Println("Ignoring miner payout that hasn't matured yet")
+					continue
+				}
+				for i, minerPayout := range block.RawBlock.MinerPayouts {
+					if minerPayout.UnlockHash == addr {
+						fmt.Println("Found miner output with value ", minerPayout.Value)
+						fmt.Println("Block: ", block.Height)
+						for _, c := range block.MinerPayoutIDs {
+							fmt.Println("Adding miner payout id", c.String())
+						}
+						w.unspentCoinOutputs[block.MinerPayoutIDs[i]] = minerPayout
+					}
+				}
+			}
 
 			// Collect the transaction outputs
 			for _, txn := range resp.Transactions {

--- a/modules/explorer/update.go
+++ b/modules/explorer/update.go
@@ -53,6 +53,7 @@ func (e *Explorer) ProcessConsensusChange(cc modules.ConsensusChange) {
 				scoid := block.MinerPayoutID(uint64(j))
 				dbRemoveCoinOutputID(tx, scoid, tbid)
 				dbRemoveUnlockHash(tx, payout.UnlockHash, tbid)
+				dbRemoveCoinOutput(tx, scoid)
 			}
 
 			// Remove transactions
@@ -111,6 +112,7 @@ func (e *Explorer) ProcessConsensusChange(cc modules.ConsensusChange) {
 				scoid := block.MinerPayoutID(uint64(j))
 				dbAddCoinOutputID(tx, scoid, tbid)
 				dbAddUnlockHash(tx, payout.UnlockHash, tbid)
+				dbAddCoinOutput(tx, scoid, payout)
 			}
 
 			// Update cumulative stats for applied transactions.


### PR DESCRIPTION
fixes #61:

It seems that the miner reward was not added to the `CoinOutput` bucket of the explorer DB. When info was then requested about a block or transaction in which a miner fee was spent, the explorer check to see if the output being spent actually existed failed, causing a panic in debug mode. These missing outputs are now added in the ProcessConsensusChange method. (Or removed, if blocks get reverted)

I also enabled the spending of miner fees in the offline transaction example, as this now no longer causes a crash due to the explorer panic on subsequent invocations of the example on the same chain (in case a miner fee was spent)