### PR TITLE
Fix blockcreator race

### DIFF
--- a/modules/blockcreator/blockcreator.go
+++ b/modules/blockcreator/blockcreator.go
@@ -19,6 +19,9 @@ type BlockCreator struct {
 	tpool  modules.TransactionPool
 	wallet modules.Wallet
 
+	// Cache the synced state of the consensus set to avoid unnecessarily locking it
+	csSynced bool
+
 	unsolvedBlock *types.Block
 
 	log        *persist.Logger

--- a/modules/blockcreator/proofofblockstake.go
+++ b/modules/blockcreator/proofofblockstake.go
@@ -25,9 +25,13 @@ func (bc *BlockCreator) SolveBlocks() {
 
 		// This is mainly here to avoid the creation of useless blocks during IBD and when a node comes back online
 		// after some downtime
-		if !bc.cs.Synced() {
-			bc.log.Debugln("Consensus set is not synced, don't create blocks")
-			time.Sleep(8 * time.Second)
+		if !bc.csSynced {
+			if !bc.cs.Synced() {
+				bc.log.Debugln("Consensus set is not synced, don't create blocks")
+				time.Sleep(8 * time.Second)
+				continue
+			}
+			bc.csSynced = true
 		}
 
 		// Try to solve a block for blocktimes of the next 10 seconds


### PR DESCRIPTION
Solve a reasonably frequent race condition when the block creator tries to solve a block just as it receives a consensus change. Also avoid creating blocks until we are fully synced to save some  system resources that would otherwise be wasted on useless blocks, especially during IBD on a new node (probably nothing major).

I feel that it is better to cache the synced state on the blockcreator struct, as this avoids a (relatively) expensive readlock to check the consensus sync state itself. Also, it only ever switches from false to true once we caught up after a (re)start of rivined.

As for the readlock on the `solveBlock` metod, I'm not sure if it is best to readlock here just to lock the height variable from the consensus change, or if we should lock in the parent method (`SolveBlocks`), locking untill we submitted a possible block to the consensus set. 