### PR TITLE
Issue 119: Don't use seed as password

### DIFF
--- a/pkg/client/defaultclient.go
+++ b/pkg/client/defaultclient.go
@@ -18,8 +18,7 @@ import (
 
 // flags
 var (
-	addr         string // override default API address
-	initPassword bool   // supply a custom password when creating a wallet
+	addr string // override default API address
 )
 
 var (
@@ -249,16 +248,32 @@ func DefaultClient() {
 	updateCmd.AddCommand(updateCheckCmd)
 
 	root.AddCommand(walletCmd)
-	walletCmd.AddCommand(walletAddressCmd, walletAddressesCmd, walletInitCmd,
-		walletLoadCmd, walletLockCmd, walletSeedsCmd, walletSendCmd,
-		walletBalanceCmd, walletTransactionsCmd, walletUnlockCmd,
-		walletBlockStakeStatCmd, walletRegisterDataCmd)
-	walletInitCmd.Flags().BoolVarP(&initPassword, "password", "p", false, "Prompt for a custom password")
-	walletSendCmd.AddCommand(walletSendSiacoinsCmd, walletSendSiafundsCmd)
+	walletCmd.AddCommand(
+		walletAddressCmd,
+		walletAddressesCmd,
+		walletInitCmd,
+		walletLoadCmd,
+		walletLockCmd,
+		walletSeedsCmd,
+		walletSendCmd,
+		walletBalanceCmd,
+		walletTransactionsCmd,
+		walletUnlockCmd,
+		walletBlockStakeStatCmd,
+		walletRegisterDataCmd)
+
+	walletSendCmd.AddCommand(
+		walletSendSiacoinsCmd,
+		walletSendSiafundsCmd)
+
 	walletLoadCmd.AddCommand(walletLoadSeedCmd)
 
 	root.AddCommand(gatewayCmd)
-	gatewayCmd.AddCommand(gatewayConnectCmd, gatewayDisconnectCmd, gatewayAddressCmd, gatewayListCmd)
+	gatewayCmd.AddCommand(
+		gatewayConnectCmd,
+		gatewayDisconnectCmd,
+		gatewayAddressCmd,
+		gatewayListCmd)
 
 	root.AddCommand(consensusCmd)
 

--- a/pkg/client/walletcmd.go
+++ b/pkg/client/walletcmd.go
@@ -175,24 +175,32 @@ func Walletaddressescmd() {
 // Walletinitcmd encrypts the wallet with the given password
 func Walletinitcmd() {
 	var er api.WalletInitPOST
-	qs := fmt.Sprintf("dictionary=%s", "english")
-	if initPassword {
-		password, err := speakeasy.Ask("Wallet password: ")
-		if err != nil {
-			Die("Reading password failed:", err)
-		}
-		qs += fmt.Sprintf("&encryptionpassword=%s", password)
+
+	fmt.Println("You should provide a password, it may be empty if you wish.")
+
+	password, err := speakeasy.Ask("Wallet password: ")
+	if err != nil {
+		Die("Reading password failed:", err)
 	}
-	err := PostResp("/wallet/init", qs, &er)
+
+	repasswd, err := speakeasy.Ask("Reenter password: ")
+	if err != nil {
+		Die("Reading password failed:", err)
+	}
+
+	if repasswd != password {
+		Die("Passwords does not match !!")
+	}
+
+	qs := fmt.Sprintf("dictionary=%s&encryptionpassword=%s", "english", password)
+
+	err = PostResp("/wallet/init", qs, &er)
 	if err != nil {
 		Die("Error when encrypting wallet:", err)
 	}
+
 	fmt.Printf("Recovery seed:\n%s\n\n", er.PrimarySeed)
-	if initPassword {
-		fmt.Printf("Wallet encrypted with given password\n")
-	} else {
-		fmt.Printf("Wallet encrypted with password:\n%s\n", er.PrimarySeed)
-	}
+	fmt.Printf("Wallet encrypted with given password\n")
 }
 
 // Walletloadseedcmd adds a seed to the wallet's list of seeds

--- a/pkg/client/walletcmd.go
+++ b/pkg/client/walletcmd.go
@@ -189,7 +189,7 @@ func Walletinitcmd() {
 	}
 
 	if repasswd != password {
-		Die("Passwords does not match !!")
+		Die("Passwords do not match !!")
 	}
 
 	qs := fmt.Sprintf("dictionary=%s&encryptionpassword=%s", "english", password)


### PR DESCRIPTION
We did not want to use the seed as a password initializing a
wallet when the user did no provide one.

So we have removed the password -p flag, now every wallet initialization
will ask the user for a password and a verification.

In my machine setting the password complains with **Error when encrypting wallet: error when calling /wallet/init: The number of bits must be divisible by 32** but the wallet is initialized and with the password selected.