### PR TITLE
add transaction short ID and consensus-get-transaction func

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -158,6 +158,7 @@ func New(requiredUserAgent string, requiredPassword string, cs modules.Consensus
 	// Consensus API Calls
 	if api.cs != nil {
 		router.GET("/consensus", api.consensusHandler)
+		router.GET("/consensus/transactions/:shortid", api.consensusGetTransactionHandler)
 	}
 
 	// Explorer API Calls

--- a/api/consensus_test.go
+++ b/api/consensus_test.go
@@ -36,6 +36,8 @@ func TestIntegrationConsensusGET(t *testing.T) {
 	}
 }
 
+// TODO: add unit test here for TestConsensusGetTransaction
+
 // TestConsensusValidateTransactionSet probes the POST call to
 // /consensus/validate/transactionset.
 func TestConsensusValidateTransactionSet(t *testing.T) {

--- a/doc/api/api.raml
+++ b/doc/api/api.raml
@@ -431,6 +431,19 @@ types:
           Succesfully retrieved consensus
         body:
           type: Consensus
+  /transactions/{shortid}:
+    description: |
+      Fetches an existing transaction from a block within the blockchain, using a given shortID.
+    responses:
+      200:
+        description: |
+          Succesfully retrieved transaction
+        body:
+          type: Transaction
+      204:
+        description: |
+          Succesfully lookup, no transaction available for the given short ID
+
 /gateway:
   get:
     description: |

--- a/modules/consensus.go
+++ b/modules/consensus.go
@@ -158,6 +158,11 @@ type (
 		// bool to indicate whether that block exists.
 		BlockHeightOfBlock(types.Block) (types.BlockHeight, bool)
 
+		// TransactionAtShortID allows you fetch a transaction from a block within
+		// the blockchain, using a given shortID.
+		// If that transaction does not exist, false is returned.
+		TransactionAtShortID(shortID types.TransactionShortID) (types.Transaction, bool)
+
 		// ChildTarget returns the target required to extend the current heaviest
 		// fork. This function is typically used by miners looking to extend the
 		// heaviest fork.

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -227,6 +227,23 @@ func (cs *ConsensusSet) BlockHeightOfBlock(block types.Block) (height types.Bloc
 	return height, exists
 }
 
+// TransactionAtShortID allows you fetch a transaction from a block within the blockchain,
+// using a given shortID.  If that transaction does not exist, false is returned.
+func (cs *ConsensusSet) TransactionAtShortID(shortID types.TransactionShortID) (types.Transaction, bool) {
+	height := shortID.BlockHeight()
+	block, found := cs.BlockAtHeight(height)
+	if !found {
+		return types.Transaction{}, false
+	}
+
+	txSeqID := int(shortID.TransactionSequenceIndex())
+	if len(block.Transactions) <= txSeqID {
+		return types.Transaction{}, false
+	}
+
+	return block.Transactions[txSeqID], true
+}
+
 // ChildTarget returns the target for the child of a block.
 func (cs *ConsensusSet) ChildTarget(id types.BlockID) (target types.Target, exists bool) {
 	// A call to a closed database can cause undefined behavior.
@@ -355,3 +372,7 @@ func (cs *ConsensusSet) MinimumValidChildTimestamp(id types.BlockID) (timestamp 
 	})
 	return timestamp, exists
 }
+
+var (
+	_ modules.ConsensusSet = (*ConsensusSet)(nil)
+)

--- a/modules/wallet/wallet_test.go
+++ b/modules/wallet/wallet_test.go
@@ -381,6 +381,21 @@ func (css *consensusSetStub) BlockHeightOfBlock(block types.Block) (types.BlockH
 	return 0, false
 }
 
+func (css *consensusSetStub) TransactionAtShortID(shortID types.TransactionShortID) (types.Transaction, bool) {
+	height := shortID.BlockHeight()
+	block, found := css.BlockAtHeight(height)
+	if !found {
+		return types.Transaction{}, false
+	}
+
+	txSeqID := int(shortID.TransactionSequenceIndex())
+	if len(block.Transactions) <= txSeqID {
+		return types.Transaction{}, false
+	}
+
+	return block.Transactions[txSeqID], true
+}
+
 func (css *consensusSetStub) ChildTarget(id types.BlockID) (types.Target, bool) {
 	// TODO: return a more sensible value if required
 	return types.Target{}, false

--- a/pkg/client/defaultclient.go
+++ b/pkg/client/defaultclient.go
@@ -276,6 +276,9 @@ func DefaultClient() {
 		gatewayListCmd)
 
 	root.AddCommand(consensusCmd)
+	consensusCmd.AddCommand(
+		consensusTransactionCmd,
+	)
 
 	// parse flags
 	root.PersistentFlags().StringVarP(&addr, "addr", "a", "localhost:23110", fmt.Sprintf("which host/port to communicate with (i.e. the host/port %sd is listening on)", ClientName))

--- a/types/transactions_test.go
+++ b/types/transactions_test.go
@@ -80,3 +80,33 @@ func TestSpecifierMarshaling(t *testing.T) {
 		t.Fatal("Unmarshal should have failed")
 	}
 }
+
+func TestTransactionShortID(t *testing.T) {
+	testCases := []struct {
+		Height       BlockHeight
+		TxSequenceID uint16
+		ShortTxID    TransactionShortID
+	}{
+		// nil/default/zero, and also minimum
+		{0, 0, 0},
+		// the maximum possible value
+		{1125899906842623, 16383, 18446744073709551615},
+		// some other examples
+		{1, 2, 16386},
+		{0, 16383, 16383},
+		{1125899906842623, 0, 18446744073709535232},
+		{42, 13, 688141},
+	}
+	for _, testCase := range testCases {
+		shortID := NewTransactionShortID(testCase.Height, testCase.TxSequenceID)
+		if shortID != testCase.ShortTxID {
+			t.Errorf("shortID (%v) != %v", shortID, testCase.ShortTxID)
+		}
+		if bh := shortID.BlockHeight(); bh != testCase.Height {
+			t.Errorf("block height (%v) != %v", bh, testCase.Height)
+		}
+		if tsid := shortID.TransactionSequenceIndex(); tsid != testCase.TxSequenceID {
+			t.Errorf("transaction seq ID (%v) != %v", tsid, testCase.TxSequenceID)
+		}
+	}
+}


### PR DESCRIPTION
+ add TransactionShortID type (closes #149);
+ add GetTransactionAtShortID function to ConsensusSet:
  + this is also exposed as the '/consensus/transactions/:shortid' endpoint;
  + the newly exposed endpoint is also available as
    'rivinec consensus transaction <shortID>';