### PR TITLE
Fix the progress estimation when syncing the blockchain

### DIFF
--- a/pkg/client/consensuscmd.go
+++ b/pkg/client/consensuscmd.go
@@ -50,8 +50,10 @@ Progress (estimated): %.f%%
 // Block height is estimated by calculating the minutes since a known block in
 // the past and dividing by 10 minutes (the block time).
 func EstimatedHeightAt(t time.Time) types.BlockHeight {
-	block5e4Timestamp := time.Date(2016, time.May, 11, 19, 33, 0, 0, time.UTC)
-	diff := t.Sub(block5e4Timestamp)
-	estimatedHeight := 5e4 + (diff.Minutes() / 10)
-	return types.BlockHeight(estimatedHeight + 0.5) // round to the nearest block
+	// Calc the amount of time passed since the Genesis block
+	genesisTime := time.Unix(int64(types.GenesisTimestamp), 0)
+	diff := t.Sub(genesisTime)
+	// Estimated number of blocks, at a rate of 10/minute
+	estimatedHeight := (diff.Minutes() / 10)
+	return types.BlockHeight(estimatedHeight)
 }

--- a/types/constants.go
+++ b/types/constants.go
@@ -66,7 +66,7 @@ func init() {
 		// Change as necessary. If not changed, the first few difficulty addaptions
 		// will be wrong, but after some new difficulty calculations the error will
 		// fade out.
-		GenesisTimestamp = Timestamp(1424139000)
+		GenesisTimestamp = Timestamp(1519560000) // 25 Feb 2018 12:00 UTC
 
 		TargetWindow = 20                        // Difficulty is adjusted based on prior 20 blocks.
 		MaxAdjustmentUp = big.NewRat(120, 100)   // Difficulty adjusts quickly.


### PR DESCRIPTION
Using the genesis timestamp as defined in the code.
Changed the timestamp of the genesis block to make accurate
estimation of the number of blocks in the chain

Applied the changes you requested, also changed the genesis timestamp to make it work, the genesis timestamp constant is not used in the code, so it is harmless.