### PR TITLE
use blockchain-specific name and version

### DIFF
--- a/cmd/rivined/main.go
+++ b/cmd/rivined/main.go
@@ -5,7 +5,6 @@ import "github.com/rivine/rivine/pkg/daemon"
 // main establishes a set of commands and flags using the cobra package.
 func main() {
 	// Daemon name defaults to rivine if it isn't set, but do so anyway just to make sure
-	daemon.DaemonName = "rivine"
 	cfg := daemon.DefaultConfig()
 	daemon.SetupDefaultDaemon(cfg)
 }

--- a/modules/blockcreator/blockcreator.go
+++ b/modules/blockcreator/blockcreator.go
@@ -19,6 +19,8 @@ type BlockCreator struct {
 	tpool  modules.TransactionPool
 	wallet modules.Wallet
 
+	bcInfo types.BlockchainInfo
+
 	// Cache the synced state of the consensus set to avoid unnecessarily locking it
 	csSynced bool
 
@@ -68,7 +70,7 @@ func (b *BlockCreator) startupRescan() error {
 }
 
 // New returns a block creator that is collaborating in the pobs protocol.
-func New(cs modules.ConsensusSet, tpool modules.TransactionPool, w modules.Wallet, persistDir string) (*BlockCreator, error) {
+func New(cs modules.ConsensusSet, tpool modules.TransactionPool, w modules.Wallet, persistDir string, bcInfo types.BlockchainInfo) (*BlockCreator, error) {
 	// Create the block creator and its dependencies.
 	if cs == nil {
 		return nil, errors.New("A consensset is required to create a block creator")
@@ -85,6 +87,8 @@ func New(cs modules.ConsensusSet, tpool modules.TransactionPool, w modules.Walle
 		cs:     cs,
 		tpool:  tpool,
 		wallet: w,
+
+		bcInfo: bcInfo,
 
 		unsolvedBlock: &types.Block{},
 

--- a/modules/blockcreator/persist.go
+++ b/modules/blockcreator/persist.go
@@ -52,7 +52,8 @@ func (b *BlockCreator) initPersist() error {
 	}
 
 	// Add a logger.
-	b.log, err = persist.NewFileLogger(filepath.Join(b.persistDir, logFile))
+	b.log, err = persist.NewFileLogger(b.bcInfo,
+		filepath.Join(b.persistDir, logFile))
 	if err != nil {
 		return err
 	}

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -92,12 +92,14 @@ type ConsensusSet struct {
 	mu         demotemutex.DemoteMutex
 	persistDir string
 	tg         sync.ThreadGroup
+
+	bcInfo types.BlockchainInfo
 }
 
 // New returns a new ConsensusSet, containing at least the genesis block. If
 // there is an existing block database present in the persist directory, it
 // will be loaded.
-func New(gateway modules.Gateway, bootstrap bool, persistDir string) (*ConsensusSet, error) {
+func New(gateway modules.Gateway, bootstrap bool, persistDir string, bcInfo types.BlockchainInfo) (*ConsensusSet, error) {
 	// Check for nil dependencies.
 	if gateway == nil {
 		return nil, errNilGateway
@@ -121,6 +123,8 @@ func New(gateway modules.Gateway, bootstrap bool, persistDir string) (*Consensus
 		blockRuleHelper: stdBlockRuleHelper{},
 
 		persistDir: persistDir,
+
+		bcInfo: bcInfo,
 	}
 
 	cs.blockValidator = NewBlockValidator(cs)

--- a/modules/consensus/persist.go
+++ b/modules/consensus/persist.go
@@ -64,7 +64,8 @@ func (cs *ConsensusSet) initPersist() error {
 	}
 
 	// Initialize the logger.
-	cs.log, err = persist.NewFileLogger(filepath.Join(cs.persistDir, logFile))
+	cs.log, err = persist.NewFileLogger(cs.bcInfo,
+		filepath.Join(cs.persistDir, logFile))
 	if err != nil {
 		return err
 	}

--- a/modules/explorer/explorer.go
+++ b/modules/explorer/explorer.go
@@ -38,12 +38,13 @@ type (
 		cs         modules.ConsensusSet
 		db         *persist.BoltDatabase
 		persistDir string
+		bcInfo     types.BlockchainInfo
 	}
 )
 
 // New creates the internal data structures, and subscribes to
 // consensus for changes to the blockchain
-func New(cs modules.ConsensusSet, persistDir string) (*Explorer, error) {
+func New(cs modules.ConsensusSet, persistDir string, bcInfo types.BlockchainInfo) (*Explorer, error) {
 	// Check that input modules are non-nil
 	if cs == nil {
 		return nil, errNilCS
@@ -53,6 +54,7 @@ func New(cs modules.ConsensusSet, persistDir string) (*Explorer, error) {
 	e := &Explorer{
 		cs:         cs,
 		persistDir: persistDir,
+		bcInfo:     bcInfo,
 	}
 
 	// Initialize the persistent structures, including the database.

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -6,114 +6,113 @@
 package gateway
 
 import (
-	"time"
-)
-
-// For the user to be securely connected to the network, the user must be
-// connected to at least one node which will send them all of the blocks. An
-// attacker can trick the user into thinking that a different blockchain is the
-// full blockchain if the user is not connected to any nodes who are seeing +
-// broadcasting the real chain (and instead is connected only to attacker nodes
-// or to nodes that are not broadcasting). This situation is called an eclipse
-// attack.
-//
-// Connecting to a large number of nodes increases the resiliancy of the
-// network, but also puts a networking burden on the nodes and can slow down
-// block propagation or increase orphan rates. The gateway's job is to keep the
-// network efficient while also protecting the user against attacks.
-//
-// The gateway keeps a list of nodes that it knows about. It uses this list to
-// form connections with other nodes, and then uses those connections to
-// participate in the flood network. The primary vector for an attacker to
-// achieve an eclipse attack is node list domination. If a gateway's nodelist
-// is heavily dominated by attacking nodes, then when the gateway chooses to
-// make random connections the gateway is at risk of selecting only attacker
-// nodes.
-//
-// The gateway defends itself from these attacks by minimizing the amount of
-// control that an attacker has over the node list and peer list. The first
-// major defense is that the gateway maintains 8 'outbound' relationships,
-// which means that the gateway created those relationships instead of an
-// attacker. If a node forms a connection to you, that node is called
-// 'inbound', and because it may be an attacker node, it is not trusted.
-// Outbound nodes can also be attacker nodes, but they are less likely to be
-// attacker nodes because you chose them, instead of them choosing you.
-//
-// If the gateway forms too many connections, the gateway will allow incoming
-// connections by kicking an existing peer. But, to limit the amount of control
-// that an attacker may have, only inbound peers are selected to be kicked.
-// Furthermore, to increase the difficulty of attack, if a new inbound
-// connection shares the same IP address as an existing connection, the shared
-// connection is the connection that gets dropped (unless that connection is a
-// local or outbound connection).
-//
-// Nodes are added to a peerlist in two methods. The first method is that a
-// gateway will ask its outbound peers for a list of nodes. If the node list is
-// below a certain size (see consts.go), the gateway will repeatedly ask
-// outbound peers to expand the list. Nodes are also added to the nodelist
-// after they successfully form a connection with the gateway. To limit the
-// attacker's ability to add nodes to the nodelist, connections are
-// ratelimited. An attacker with lots of IP addresses still has the ability to
-// fill up the nodelist, however getting 90% dominance of the nodelist requries
-// forming thousands of connections, which will take hours or days. By that
-// time, the attacked node should already have its set of outbound peers,
-// limiting the amount of damage that the attacker can do.
-//
-// To limit DNS-based tomfoolry, nodes are only added to the nodelist if their
-// connection information takes the form of an IP address.
-//
-// Some research has been done on Bitcoin's flood networks. The more relevant
-// research has been listed below. The papers listed first are more relevant.
-//     Eclipse Attacks on Bitcoin's Peer-to-Peer Network (Heilman, Kendler, Zohar, Goldberg)
-//     Stubborn Mining: Generalizing Selfish Mining and Combining with an Eclipse Attack (Nayak, Kumar, Miller, Shi)
-//     An Overview of BGP Hijacking (https://www.bishopfox.com/blog/2015/08/an-overview-of-bgp-hijacking/)
-
-// TODO: Currently the gateway does not do much in terms of bucketing. The
-// gateway should make sure that it has outbound peers from a wide range of IP
-// addresses, and when kicking inbound peers it shouldn't just favor kicking
-// peers of the same IP address, it should favor kicking peers of the same ip
-// address range.
-//
-// TODO: Currently the gateway does not save a list of its outbound
-// connections. When it restarts, it will have a full nodelist (which may be
-// primarily attacker nodes) and it will be connecting primarily to nodes in
-// the nodelist. Instead, it should start by trying to connect to peers that
-// have previously been outbound peers, as it is less likely that those have
-// been manipulated.
-//
-// TODO: There is no public key exhcange,
-// so communications cannot be effectively encrypted or authenticated.
-// The nodes must have some way to share keys.
-//
-// TODO: Gateway hostname discovery currently has significant centralization,
-// namely the fallback is a single third-party website that can easily form any
-// response it wants. Instead, multiple TLS-protected third party websites
-// should be used, and the plurality answer should be accepted as the true
-// hostname.
-//
-// TODO: The gateway currently does hostname discovery in a non-blocking way,
-// which means that the first few peers that it connects to may not get the
-// correct hostname. This means that you may give the remote peer the wrong
-// hostname, which means they will not be able to dial you back, which means
-// they will not add you to their node list.
-//
-// TODO: The gateway should encrypt and authenticate all communications. Though
-// the gateway participates in a flood network, practical attacks have been
-// demonstrated which have been able to confuse nodes by manipulating messages
-// from their peers. Encryption + authentication would have made the attack
-// more difficult.
-
-import (
 	"errors"
 	"fmt"
 	"net"
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/NebulousLabs/fastrand"
 	"github.com/rivine/rivine/modules"
 	"github.com/rivine/rivine/persist"
+	"github.com/rivine/rivine/types"
+
+	// For the user to be securely connected to the network, the user must be
+	// connected to at least one node which will send them all of the blocks. An
+	// attacker can trick the user into thinking that a different blockchain is the
+	// full blockchain if the user is not connected to any nodes who are seeing +
+	// broadcasting the real chain (and instead is connected only to attacker nodes
+	// or to nodes that are not broadcasting). This situation is called an eclipse
+	// attack.
+	//
+	// Connecting to a large number of nodes increases the resiliancy of the
+	// network, but also puts a networking burden on the nodes and can slow down
+	// block propagation or increase orphan rates. The gateway's job is to keep the
+	// network efficient while also protecting the user against attacks.
+	//
+	// The gateway keeps a list of nodes that it knows about. It uses this list to
+	// form connections with other nodes, and then uses those connections to
+	// participate in the flood network. The primary vector for an attacker to
+	// achieve an eclipse attack is node list domination. If a gateway's nodelist
+	// is heavily dominated by attacking nodes, then when the gateway chooses to
+	// make random connections the gateway is at risk of selecting only attacker
+	// nodes.
+	//
+	// The gateway defends itself from these attacks by minimizing the amount of
+	// control that an attacker has over the node list and peer list. The first
+	// major defense is that the gateway maintains 8 'outbound' relationships,
+	// which means that the gateway created those relationships instead of an
+	// attacker. If a node forms a connection to you, that node is called
+	// 'inbound', and because it may be an attacker node, it is not trusted.
+	// Outbound nodes can also be attacker nodes, but they are less likely to be
+	// attacker nodes because you chose them, instead of them choosing you.
+	//
+	// If the gateway forms too many connections, the gateway will allow incoming
+	// connections by kicking an existing peer. But, to limit the amount of control
+	// that an attacker may have, only inbound peers are selected to be kicked.
+	// Furthermore, to increase the difficulty of attack, if a new inbound
+	// connection shares the same IP address as an existing connection, the shared
+	// connection is the connection that gets dropped (unless that connection is a
+	// local or outbound connection).
+	//
+	// Nodes are added to a peerlist in two methods. The first method is that a
+	// gateway will ask its outbound peers for a list of nodes. If the node list is
+	// below a certain size (see consts.go), the gateway will repeatedly ask
+	// outbound peers to expand the list. Nodes are also added to the nodelist
+	// after they successfully form a connection with the gateway. To limit the
+	// attacker's ability to add nodes to the nodelist, connections are
+	// ratelimited. An attacker with lots of IP addresses still has the ability to
+	// fill up the nodelist, however getting 90% dominance of the nodelist requries
+	// forming thousands of connections, which will take hours or days. By that
+	// time, the attacked node should already have its set of outbound peers,
+	// limiting the amount of damage that the attacker can do.
+	//
+	// To limit DNS-based tomfoolry, nodes are only added to the nodelist if their
+	// connection information takes the form of an IP address.
+	//
+	// Some research has been done on Bitcoin's flood networks. The more relevant
+	// research has been listed below. The papers listed first are more relevant.
+	//     Eclipse Attacks on Bitcoin's Peer-to-Peer Network (Heilman, Kendler, Zohar, Goldberg)
+	//     Stubborn Mining: Generalizing Selfish Mining and Combining with an Eclipse Attack (Nayak, Kumar, Miller, Shi)
+	//     An Overview of BGP Hijacking (https://www.bishopfox.com/blog/2015/08/an-overview-of-bgp-hijacking/)
+
+	// TODO: Currently the gateway does not do much in terms of bucketing. The
+	// gateway should make sure that it has outbound peers from a wide range of IP
+	// addresses, and when kicking inbound peers it shouldn't just favor kicking
+	// peers of the same IP address, it should favor kicking peers of the same ip
+	// address range.
+	//
+	// TODO: Currently the gateway does not save a list of its outbound
+	// connections. When it restarts, it will have a full nodelist (which may be
+	// primarily attacker nodes) and it will be connecting primarily to nodes in
+	// the nodelist. Instead, it should start by trying to connect to peers that
+	// have previously been outbound peers, as it is less likely that those have
+	// been manipulated.
+	//
+	// TODO: There is no public key exhcange,
+	// so communications cannot be effectively encrypted or authenticated.
+	// The nodes must have some way to share keys.
+	//
+	// TODO: Gateway hostname discovery currently has significant centralization,
+	// namely the fallback is a single third-party website that can easily form any
+	// response it wants. Instead, multiple TLS-protected third party websites
+	// should be used, and the plurality answer should be accepted as the true
+	// hostname.
+	//
+	// TODO: The gateway currently does hostname discovery in a non-blocking way,
+	// which means that the first few peers that it connects to may not get the
+	// correct hostname. This means that you may give the remote peer the wrong
+	// hostname, which means they will not be able to dial you back, which means
+	// they will not add you to their node list.
+	//
+	// TODO: The gateway should encrypt and authenticate all communications. Though
+	// the gateway participates in a flood network, practical attacks have been
+	// demonstrated which have been able to confuse nodes by manipulating messages
+	// from their peers. Encryption + authentication would have made the attack
+	// more difficult.
+
 	siasync "github.com/rivine/rivine/sync"
 )
 
@@ -161,6 +160,8 @@ type Gateway struct {
 
 	// Unique ID
 	id gatewayID
+
+	bcInfo types.BlockchainInfo
 }
 
 type gatewayID [8]byte
@@ -195,7 +196,7 @@ func (g *Gateway) Close() error {
 }
 
 // New returns an initialized Gateway.
-func New(addr string, bootstrap bool, persistDir string) (*Gateway, error) {
+func New(addr string, bootstrap bool, persistDir string, bcInfo types.BlockchainInfo) (*Gateway, error) {
 	// Create the directory if it doesn't exist.
 	err := os.MkdirAll(persistDir, 0700)
 	if err != nil {
@@ -210,13 +211,16 @@ func New(addr string, bootstrap bool, persistDir string) (*Gateway, error) {
 		nodes: make(map[modules.NetAddress]struct{}),
 
 		persistDir: persistDir,
+
+		bcInfo: bcInfo,
 	}
 
 	// Set Unique GatewayID
 	fastrand.Read(g.id[:])
 
 	// Create the logger.
-	g.log, err = persist.NewFileLogger(filepath.Join(g.persistDir, logFile))
+	g.log, err = persist.NewFileLogger(bcInfo,
+		filepath.Join(g.persistDir, logFile))
 	if err != nil {
 		return nil, err
 	}

--- a/modules/gateway/gateway_test.go
+++ b/modules/gateway/gateway_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rivine/rivine/build"
 	"github.com/rivine/rivine/modules"
 	siasync "github.com/rivine/rivine/sync"
+	"github.com/rivine/rivine/types"
 )
 
 // newTestingGateway returns a gateway ready to use in a testing environment.
@@ -20,7 +21,8 @@ func newTestingGateway(t *testing.T) *Gateway {
 		panic("newTestingGateway called during short test")
 	}
 
-	g, err := New("localhost:0", false, build.TempDir("gateway", t.Name()))
+	g, err := New("localhost:0", false, build.TempDir("gateway", t.Name()),
+		types.DefaultBlockchainInfo())
 	if err != nil {
 		panic(err)
 	}
@@ -34,7 +36,8 @@ func newNamedTestingGateway(t *testing.T, suffix string) *Gateway {
 		panic("newTestingGateway called during short test")
 	}
 
-	g, err := New("localhost:0", false, build.TempDir("gateway", t.Name()+suffix))
+	g, err := New("localhost:0", false, build.TempDir("gateway", t.Name()+suffix),
+		types.DefaultBlockchainInfo())
 	if err != nil {
 		panic(err)
 	}
@@ -127,13 +130,14 @@ func TestNew(t *testing.T) {
 	}
 	t.Parallel()
 
-	if _, err := New("", false, ""); err == nil {
+	bcInfo := types.DefaultBlockchainInfo()
+	if _, err := New("", false, "", bcInfo); err == nil {
 		t.Fatal("expecting persistDir error, got nil")
 	}
-	if _, err := New("localhost:0", false, ""); err == nil {
+	if _, err := New("localhost:0", false, "", bcInfo); err == nil {
 		t.Fatal("expecting persistDir error, got nil")
 	}
-	if g, err := New("foo", false, build.TempDir("gateway", t.Name()+"1")); err == nil {
+	if g, err := New("foo", false, build.TempDir("gateway", t.Name()+"1"), bcInfo); err == nil {
 		t.Fatal("expecting listener error, got nil", g.myAddr)
 	}
 	// create corrupted nodes.json
@@ -143,7 +147,7 @@ func TestNew(t *testing.T) {
 	if err != nil {
 		t.Fatal("couldn't create corrupted file:", err)
 	}
-	if _, err := New("localhost:0", false, dir); err == nil {
+	if _, err := New("localhost:0", false, dir, bcInfo); err == nil {
 		t.Fatal("expected load error, got nil")
 	}
 }

--- a/modules/gateway/persist_test.go
+++ b/modules/gateway/persist_test.go
@@ -2,6 +2,8 @@ package gateway
 
 import (
 	"testing"
+
+	"github.com/rivine/rivine/types"
 )
 
 func TestLoad(t *testing.T) {
@@ -17,7 +19,7 @@ func TestLoad(t *testing.T) {
 	g.mu.Unlock()
 	g.Close()
 
-	g2, err := New("localhost:0", false, g.persistDir)
+	g2, err := New("localhost:0", false, g.persistDir, types.DefaultBlockchainInfo())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/transactionpool/transactionpool.go
+++ b/modules/transactionpool/transactionpool.go
@@ -72,11 +72,13 @@ type (
 		db         *persist.BoltDatabase
 		mu         demotemutex.DemoteMutex
 		persistDir string
+
+		bcInfo types.BlockchainInfo
 	}
 )
 
 // New creates a transaction pool that is ready to receive transactions.
-func New(cs modules.ConsensusSet, g modules.Gateway, persistDir string) (*TransactionPool, error) {
+func New(cs modules.ConsensusSet, g modules.Gateway, persistDir string, bcInfo types.BlockchainInfo) (*TransactionPool, error) {
 	// Check that the input modules are non-nil.
 	if cs == nil {
 		return nil, errNilCS
@@ -95,6 +97,8 @@ func New(cs modules.ConsensusSet, g modules.Gateway, persistDir string) (*Transa
 		transactionSetDiffs: make(map[TransactionSetID]modules.ConsensusChange),
 
 		persistDir: persistDir,
+
+		bcInfo: bcInfo,
 	}
 
 	// Open the tpool database.

--- a/modules/wallet/encrypt_test.go
+++ b/modules/wallet/encrypt_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/rivine/rivine/crypto"
 	"github.com/rivine/rivine/modules"
+	"github.com/rivine/rivine/types"
 )
 
 // postEncryptionTesting runs a series of checks on the wallet after it has
@@ -110,7 +111,8 @@ func TestIntegrationPreEncryption(t *testing.T) {
 
 	// Create a second wallet using the same directory - make sure that if any
 	// files have been created, the wallet is still being treated as new.
-	w1, err := New(wt.cs, wt.tpool, filepath.Join(wt.persistDir, modules.WalletDir))
+	w1, err := New(wt.cs, wt.tpool,
+		filepath.Join(wt.persistDir, modules.WalletDir), types.DefaultBlockchainInfo())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/persist.go
+++ b/modules/wallet/persist.go
@@ -114,7 +114,8 @@ func (w *Wallet) initPersist() error {
 	}
 
 	// Start logging.
-	w.log, err = persist.NewFileLogger(filepath.Join(w.persistDir, logFile))
+	w.log, err = persist.NewFileLogger(w.bcInfo,
+		filepath.Join(w.persistDir, logFile))
 	if err != nil {
 		return err
 	}

--- a/modules/wallet/seed.go
+++ b/modules/wallet/seed.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	seedFilePrefix = "Rivine Wallet Encrypted Backup Seed - "
-	seedFileSuffix = ".seed"
+	seedFilePartialPrefix = " Wallet Encrypted Backup Seed - "
+	seedFileSuffix        = ".seed"
 )
 
 var (
@@ -61,7 +61,8 @@ func (w *Wallet) encryptAndSaveSeedFile(masterKey crypto.TwofishKey, seed module
 	plaintextVerification := make([]byte, encryptionVerificationLen)
 	sf.EncryptionVerification = sek.EncryptBytes(plaintextVerification)
 	sf.Seed = sek.EncryptBytes(seed[:])
-	seedFilename := filepath.Join(w.persistDir, seedFilePrefix+persist.RandomSuffix()+seedFileSuffix)
+	seedFilename := filepath.Join(w.persistDir,
+		w.bcInfo.Name+seedFilePartialPrefix+persist.RandomSuffix()+seedFileSuffix)
 	err = persist.SaveJSON(seedMetadata, sf, seedFilename)
 	if err != nil {
 		return SeedFile{}, err

--- a/modules/wallet/seed_test.go
+++ b/modules/wallet/seed_test.go
@@ -134,7 +134,7 @@ func TestLoadSeed(t *testing.T) {
 	}
 
 	dir := filepath.Join(build.TempDir(modules.WalletDir, t.Name()+"1"), modules.WalletDir)
-	w, err := New(wt.cs, wt.tpool, dir)
+	w, err := New(wt.cs, wt.tpool, dir, types.DefaultBlockchainInfo())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -186,7 +186,7 @@ func TestLoadSeed(t *testing.T) {
 	// Rather than worry about a rescan, which isn't implemented and has
 	// synchronization difficulties, just load a new wallet from the same
 	// settings file - the same effect is achieved without the difficulties.
-	w2, err := New(wt.cs, wt.tpool, dir)
+	w2, err := New(wt.cs, wt.tpool, dir, types.DefaultBlockchainInfo())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -103,13 +103,15 @@ type Wallet struct {
 	// The wallet's ThreadGroup tells tracked functions to shut down and
 	// blocks until they have all exited before returning from Close.
 	tg siasync.ThreadGroup
+
+	bcInfo types.BlockchainInfo
 }
 
 // New creates a new wallet, loading any known addresses from the input file
 // name and then using the file to save in the future. Keys and addresses are
 // not loaded into the wallet during the call to 'new', but rather during the
 // call to 'Unlock'.
-func New(cs modules.ConsensusSet, tpool modules.TransactionPool, persistDir string) (*Wallet, error) {
+func New(cs modules.ConsensusSet, tpool modules.TransactionPool, persistDir string, bcInfo types.BlockchainInfo) (*Wallet, error) {
 	// Check for nil dependencies.
 	if cs == nil {
 		return nil, errNilConsensusSet
@@ -134,6 +136,8 @@ func New(cs modules.ConsensusSet, tpool modules.TransactionPool, persistDir stri
 		historicOutputs: make(map[types.OutputID]types.Currency),
 
 		persistDir: persistDir,
+
+		bcInfo: bcInfo,
 	}
 	err := w.initPersist()
 	if err != nil {

--- a/modules/wallet/wallet_test.go
+++ b/modules/wallet/wallet_test.go
@@ -35,22 +35,23 @@ type walletTester struct {
 
 // createWalletTester takes a testing.T and creates a WalletTester.
 func createWalletTester(name string) (*walletTester, error) {
+	bcInfo := types.DefaultBlockchainInfo()
 	// Create the modules
 	testdir := build.TempDir(modules.WalletDir, name)
-	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir), bcInfo)
 	if err != nil {
 		return nil, err
 	}
 
-	cs, err := consensus.New(g, false, filepath.Join(testdir, modules.ConsensusDir))
+	cs, err := consensus.New(g, false, filepath.Join(testdir, modules.ConsensusDir), bcInfo)
 	if err != nil {
 		return nil, err
 	}
-	tp, err := transactionpool.New(cs, g, filepath.Join(testdir, modules.TransactionPoolDir))
+	tp, err := transactionpool.New(cs, g, filepath.Join(testdir, modules.TransactionPoolDir), bcInfo)
 	if err != nil {
 		return nil, err
 	}
-	w, err := New(cs, tp, filepath.Join(testdir, modules.WalletDir))
+	w, err := New(cs, tp, filepath.Join(testdir, modules.WalletDir), bcInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -103,18 +104,19 @@ func createWalletTesterWithStubCS(name string, cs *consensusSetStub) (*walletTes
 	if cs == nil {
 		return nil, errors.New("no stub consensus set given")
 	}
+	bcInfo := types.DefaultBlockchainInfo()
 	// Create the modules
 	testdir := build.TempDir(modules.WalletDir, name)
-	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir), bcInfo)
 	if err != nil {
 		return nil, err
 	}
 
-	tp, err := transactionpool.New(cs, g, filepath.Join(testdir, modules.TransactionPoolDir))
+	tp, err := transactionpool.New(cs, g, filepath.Join(testdir, modules.TransactionPoolDir), bcInfo)
 	if err != nil {
 		return nil, err
 	}
-	w, err := New(cs, tp, filepath.Join(testdir, modules.WalletDir))
+	w, err := New(cs, tp, filepath.Join(testdir, modules.WalletDir), bcInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -164,21 +166,22 @@ func createWalletTesterWithStubCS(name string, cs *consensusSetStub) (*walletTes
 // createBlankWalletTester creates a wallet tester that has not mined any
 // blocks or encrypted the wallet.
 func createBlankWalletTester(name string) (*walletTester, error) {
+	bcInfo := types.DefaultBlockchainInfo()
 	// Create the modules
 	testdir := build.TempDir(modules.WalletDir, name)
-	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir), bcInfo)
 	if err != nil {
 		return nil, err
 	}
-	cs, err := consensus.New(g, false, filepath.Join(testdir, modules.ConsensusDir))
+	cs, err := consensus.New(g, false, filepath.Join(testdir, modules.ConsensusDir), bcInfo)
 	if err != nil {
 		return nil, err
 	}
-	tp, err := transactionpool.New(cs, g, filepath.Join(testdir, modules.TransactionPoolDir))
+	tp, err := transactionpool.New(cs, g, filepath.Join(testdir, modules.TransactionPoolDir), bcInfo)
 	if err != nil {
 		return nil, err
 	}
-	w, err := New(cs, tp, filepath.Join(testdir, modules.WalletDir))
+	w, err := New(cs, tp, filepath.Join(testdir, modules.WalletDir), bcInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -216,30 +219,31 @@ func (wt *walletTester) closeWt() {
 
 // TestNilInputs tries starting the wallet using nil inputs.
 func TestNilInputs(t *testing.T) {
+	bcInfo := types.DefaultBlockchainInfo()
 	testdir := build.TempDir(modules.WalletDir, t.Name())
-	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir), bcInfo)
 	if err != nil {
 		t.Fatal(err)
 	}
-	cs, err := consensus.New(g, false, filepath.Join(testdir, modules.ConsensusDir))
+	cs, err := consensus.New(g, false, filepath.Join(testdir, modules.ConsensusDir), bcInfo)
 	if err != nil {
 		t.Fatal(err)
 	}
-	tp, err := transactionpool.New(cs, g, filepath.Join(testdir, modules.TransactionPoolDir))
+	tp, err := transactionpool.New(cs, g, filepath.Join(testdir, modules.TransactionPoolDir), bcInfo)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	wdir := filepath.Join(testdir, modules.WalletDir)
-	_, err = New(cs, nil, wdir)
+	_, err = New(cs, nil, wdir, bcInfo)
 	if err != errNilTpool {
 		t.Error(err)
 	}
-	_, err = New(nil, tp, wdir)
+	_, err = New(nil, tp, wdir, bcInfo)
 	if err != errNilConsensusSet {
 		t.Error(err)
 	}
-	_, err = New(nil, nil, wdir)
+	_, err = New(nil, nil, wdir, bcInfo)
 	if err != errNilConsensusSet {
 		t.Error(err)
 	}
@@ -273,21 +277,22 @@ func TestCloseWallet(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
+	bcInfo := types.DefaultBlockchainInfo()
 	testdir := build.TempDir(modules.WalletDir, t.Name())
-	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir), bcInfo)
 	if err != nil {
 		t.Fatal(err)
 	}
-	cs, err := consensus.New(g, false, filepath.Join(testdir, modules.ConsensusDir))
+	cs, err := consensus.New(g, false, filepath.Join(testdir, modules.ConsensusDir), bcInfo)
 	if err != nil {
 		t.Fatal(err)
 	}
-	tp, err := transactionpool.New(cs, g, filepath.Join(testdir, modules.TransactionPoolDir))
+	tp, err := transactionpool.New(cs, g, filepath.Join(testdir, modules.TransactionPoolDir), bcInfo)
 	if err != nil {
 		t.Fatal(err)
 	}
 	wdir := filepath.Join(testdir, modules.WalletDir)
-	w, err := New(cs, tp, wdir)
+	w, err := New(cs, tp, wdir, bcInfo)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/persist/log.go
+++ b/persist/log.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/rivine/rivine/build"
+	"github.com/rivine/rivine/types"
 )
 
 // Logger is a wrapper for the standard library logger that enforces logging
@@ -73,9 +74,12 @@ func (l *Logger) Severe(v ...interface{}) {
 
 // NewLogger returns a logger that can be closed. Calls should not be made to
 // the logger after 'Close' has been called.
-func NewLogger(w io.Writer) *Logger {
+func NewLogger(info types.BlockchainInfo, w io.Writer) *Logger {
 	l := log.New(w, "", log.Ldate|log.Ltime|log.Lmicroseconds|log.Lshortfile|log.LUTC)
-	l.Output(3, "STARTUP: Logging has started. Rivined Version "+build.Version.String()) // Call depth is 3 because NewLogger is usually called by NewFileLogger
+	// Call depth is 3 because NewLogger is usually called by NewFileLogger
+	l.Output(3, fmt.Sprintf(
+		"STARTUP: Logging has started. %s Version %s",
+		info.Name, info.Version.String()))
 	return &Logger{l, w}
 }
 
@@ -118,11 +122,11 @@ func (cf *closeableFile) Write(b []byte) (int, error) {
 
 // NewFileLogger returns a logger that logs to logFilename. The file is opened
 // in append mode, and created if it does not exist.
-func NewFileLogger(logFilename string) (*Logger, error) {
+func NewFileLogger(info types.BlockchainInfo, logFilename string) (*Logger, error) {
 	logFile, err := os.OpenFile(logFilename, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0660)
 	if err != nil {
 		return nil, err
 	}
 	cf := &closeableFile{File: logFile}
-	return NewLogger(cf), nil
+	return NewLogger(info, cf), nil
 }

--- a/persist/log_test.go
+++ b/persist/log_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/rivine/rivine/build"
+	"github.com/rivine/rivine/types"
 )
 
 // TestLogger checks that the basic functions of the file logger work as
@@ -26,7 +27,7 @@ func TestLogger(t *testing.T) {
 
 	// Create the logger.
 	logFilename := filepath.Join(testdir, "test.log")
-	fl, err := NewFileLogger(logFilename)
+	fl, err := NewFileLogger(types.DefaultBlockchainInfo(), logFilename)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +72,7 @@ func TestLoggerCritical(t *testing.T) {
 
 	// Create the logger.
 	logFilename := filepath.Join(testdir, "test.log")
-	fl, err := NewFileLogger(logFilename)
+	fl, err := NewFileLogger(types.DefaultBlockchainInfo(), logFilename)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/daemon/commands.go
+++ b/pkg/daemon/commands.go
@@ -17,11 +17,6 @@ const (
 	exitCodeUsage   = 64 // EX_USAGE in sysexits.h
 )
 
-// DaemonName sets the name of the daemon, used in some help messages
-var (
-	DaemonName = "rivine"
-)
-
 // die prints its arguments to stderr, then exits the program with the default
 // error code.
 func die(args ...interface{}) {
@@ -34,7 +29,7 @@ func newStartDaemonCmd(cfg *Config) func(cmd *cobra.Command, _ []string) {
 	return func(cmd *cobra.Command, _ []string) {
 		// Create the profiling directory if profiling is enabled.
 		if cfg.Profile || build.DEBUG {
-			go profile.StartContinuousProfile(cfg.ProfileDir)
+			go profile.StartContinuousProfile(cfg.ProfileDir, cfg.BlockchainInfo)
 		}
 
 		// Start rivined. StartDaemon will only return when it is shutting down.
@@ -46,16 +41,21 @@ func newStartDaemonCmd(cfg *Config) func(cmd *cobra.Command, _ []string) {
 }
 
 // versionCmd is a cobra command that prints the version of siad.
-func versionCmd(*cobra.Command, []string) {
-	switch build.Release {
-	case "dev":
-		fmt.Println(fmt.Sprintf("%s Daemon v", strings.Title(DaemonName)) + build.Version.String() + "-dev")
-	case "standard":
-		fmt.Println(fmt.Sprintf("%s Daemon v", strings.Title(DaemonName)) + build.Version.String())
-	case "testing":
-		fmt.Println(fmt.Sprintf("%s Daemon v", strings.Title(DaemonName)) + build.Version.String() + "-testing")
-	default:
-		fmt.Println(fmt.Sprintf("%s Daemon v", strings.Title(DaemonName)) + build.Version.String() + "-???")
+func newVersionCmd(cfg *Config) func(*cobra.Command, []string) {
+	return func(*cobra.Command, []string) {
+		var postfix string
+		switch build.Release {
+		case "dev":
+			postfix = "-dev"
+		case "testing":
+			postfix = "-testing"
+		case "standard": // ""
+		default:
+			postfix = "-???"
+		}
+		fmt.Printf("%s Daemon v%s%s\n",
+			strings.Title(cfg.BlockchainInfo.Name),
+			cfg.BlockchainInfo.Version.String(), postfix)
 	}
 }
 
@@ -68,7 +68,7 @@ their first letter. If the -M or --modules flag is not specified the default
 modules are run. The default modules are:
 	gateway, consensus set, transaction pool, wallet, block creator
 This is equivalent to:
-	%[1]sd -M cgtwb
+	%[1]s -M cgtwb
 Below is a list of all the modules available.
 
 Gateway (g):
@@ -76,55 +76,58 @@ Gateway (g):
 	enables other modules to perform RPC calls on peers.
 	The gateway is required by all other modules.
 	Example:
-		%[1]sd -M g
+		%[1]s -M g
 Consensus Set (c):
 	The consensus set manages everything related to consensus and keeps the
 	blockchain in sync with the rest of the network.
 	The consensus set requires the gateway.
 	Example:
-		%[1]sd -M gc
+		%[1]s -M gc
 Transaction Pool (t):
 	The transaction pool manages unconfirmed transactions.
 	The transaction pool requires the consensus set.
 
 	Example:
-		%[1]sd -M gct
+		%[1]s -M gct
 Wallet (w):
 	The wallet stores and manages coins and blockstakes.
 	The wallet requires the consensus set and transaction pool.
 	Example:
-		%[1]sd -M gctw
+		%[1]s -M gctw
 BlockCreator (b):
 	The block creator participates in the proof of block stake protocol
 	for creating new blocks. BlockStakes are required to participate.
 	The block creator requires the consensus set, transaction pool and wallet.
 	Example:
-		%[1]sd -M gctwb
+		%[1]s -M gctwb
 Explorer (e):
 	The explorer provides statistics about the blockchain and can be
 	queried for information about specific transactions or other objects on
 	the blockchain.
 	The explorer requires the consensus set.
 	Example:
-		%[1]sd -M gce
-`, DaemonName)
+		%[1]s -M gce
+`, os.Args[0])
 }
 
 // SetupDefaultDaemon sets up and starts a default daemon. The chain options and constants
 // need to be configured prior to this. This function does not return untill the daemon is stopped
 func SetupDefaultDaemon(cfg Config) {
 	root := &cobra.Command{
-		Use:   os.Args[0],
-		Short: strings.Title(DaemonName) + " Daemon v" + build.Version.String(),
-		Long:  strings.Title(DaemonName) + " Daemon v" + build.Version.String(),
-		Run:   newStartDaemonCmd(&cfg),
+		Use: os.Args[0],
+		Short: strings.Title(cfg.BlockchainInfo.Name) + " Daemon v" +
+			cfg.BlockchainInfo.Version.String(),
+		Long: strings.Title(cfg.BlockchainInfo.Name) + " Daemon v" +
+			cfg.BlockchainInfo.Version.String(),
+		Run: newStartDaemonCmd(&cfg),
 	}
 
 	root.AddCommand(&cobra.Command{
 		Use:   "version",
 		Short: "Print version information",
-		Long:  "Print version information about the " + strings.Title(DaemonName) + " Daemon",
-		Run:   versionCmd,
+		Long: "Print version information about the " +
+			strings.Title(cfg.BlockchainInfo.Name) + " Daemon",
+		Run: newVersionCmd(&cfg),
 	})
 
 	root.AddCommand(&cobra.Command{
@@ -138,13 +141,16 @@ func SetupDefaultDaemon(cfg Config) {
 	root.Flags().StringVarP(&cfg.RequiredUserAgent, "agent", "", cfg.RequiredUserAgent, "required substring for the user agent")
 	root.Flags().StringVarP(&cfg.ProfileDir, "profile-directory", "", cfg.ProfileDir, "location of the profiling directory")
 	root.Flags().StringVarP(&cfg.APIaddr, "api-addr", "", cfg.APIaddr, "which host:port the API server listens on")
-	root.Flags().StringVarP(&cfg.RootPersistentDir, DaemonName+"-directory", "d", cfg.RootPersistentDir, "location of the "+DaemonName+" directory")
+	root.Flags().StringVarP(&cfg.RootPersistentDir, "persistent-directory", "d", cfg.RootPersistentDir,
+		"location of the root diretory used to store persistent data of the daemon of"+
+			cfg.BlockchainInfo.Name)
 	root.Flags().BoolVarP(&cfg.NoBootstrap, "no-bootstrap", "", cfg.NoBootstrap, "disable bootstrapping on this run")
 	root.Flags().BoolVarP(&cfg.Profile, "profile", "", cfg.Profile, "enable profiling")
 	root.Flags().StringVarP(&cfg.RPCaddr, "rpc-addr", "", cfg.RPCaddr, "which port the gateway listens on")
-	root.Flags().StringVarP(&cfg.Modules, "modules", "M", cfg.Modules, fmt.Sprintf("enabled modules, see '%sd modules' for more info", DaemonName))
+	root.Flags().StringVarP(&cfg.Modules, "modules", "M", cfg.Modules,
+		fmt.Sprintf("enabled modules, see '%s modules' for more info", os.Args[0]))
 	root.Flags().BoolVarP(&cfg.AuthenticateAPI, "authenticate-api", "", cfg.AuthenticateAPI, "enable API password protection")
-	root.Flags().BoolVarP(&cfg.AllowAPIBind, "disable-api-security", "", cfg.AllowAPIBind, fmt.Sprintf("allow %sd to listen on a non-localhost address (DANGEROUS)", DaemonName))
+	root.Flags().BoolVarP(&cfg.AllowAPIBind, "disable-api-security", "", cfg.AllowAPIBind, fmt.Sprintf("allow the daemon of %s to listen on a non-localhost address (DANGEROUS)", cfg.BlockchainInfo.Name))
 
 	// Parse cmdline flags, overwriting both the default values and the config
 	// file values.

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/rivine/rivine/persist"
+	"github.com/rivine/rivine/types"
 )
 
 // There's a global lock on cpu and memory profiling, because I'm not sure what
@@ -83,7 +84,7 @@ func SaveMemProfile(profileDir, identifier string) error {
 
 // StartContinuousProfiling will continuously print statistics about the cpu
 // usage, memory usage, and runtime stats of the program.
-func StartContinuousProfile(profileDir string) {
+func StartContinuousProfile(profileDir string, bcInfo types.BlockchainInfo) {
 	// Create the folder for all of the profiling results.
 	err := os.MkdirAll(profileDir, 0700)
 	if err != nil {
@@ -94,7 +95,7 @@ func StartContinuousProfile(profileDir string) {
 	// Continuously log statistics about the running Sia application.
 	go func() {
 		// Create the logger.
-		log, err := persist.NewFileLogger(filepath.Join(profileDir, "continuousProfiling.log"))
+		log, err := persist.NewFileLogger(bcInfo, filepath.Join(profileDir, "continuousProfiling.log"))
 		if err != nil {
 			fmt.Println("Profile logging failed:", err)
 			return

--- a/types/blockchain.go
+++ b/types/blockchain.go
@@ -1,0 +1,21 @@
+package types
+
+import (
+	"github.com/rivine/rivine/build"
+)
+
+// BlockchainInfo contains information about a blockchain.
+type BlockchainInfo struct {
+	Name    string
+	Version build.ProtocolVersion
+}
+
+// DefaultBlockchainInfo returns the blockchain information
+// for the default (Rivine) blockchain, using the version
+// which is set as part of the build process.
+func DefaultBlockchainInfo() BlockchainInfo {
+	return BlockchainInfo{
+		Name:    "Rivine",
+		Version: build.Version,
+	}
+}


### PR DESCRIPTION
used to be the hardcoded Rivine(d) name and build.Version,
now it is all done using a non-global info struct

fixes #118