### PR TITLE
Lookup transactions with long id

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -158,7 +158,7 @@ func New(requiredUserAgent string, requiredPassword string, cs modules.Consensus
 	// Consensus API Calls
 	if api.cs != nil {
 		router.GET("/consensus", api.consensusHandler)
-		router.GET("/consensus/transactions/:shortid", api.consensusGetTransactionHandler)
+		router.GET("/consensus/transactions/:id", api.consensusGetTransactionHandler)
 	}
 
 	// Explorer API Calls

--- a/api/consensus.go
+++ b/api/consensus.go
@@ -95,7 +95,7 @@ func (api *API) getTransactionByShortID(shortID string) (types.Transaction, erro
 // It also returns the short id for future reference
 func (api *API) getTransactionByLongID(longid string) (types.Transaction, types.TransactionShortID, error) {
 	var txID types.TransactionID
-	err := txID.UnmarshalJSON([]byte("\"" + longid + "\""))
+	err := txID.LoadString(longid)
 	if err != nil {
 		return types.Transaction{}, types.TransactionShortID(0), err
 	}

--- a/doc/api/api.raml
+++ b/doc/api/api.raml
@@ -431,15 +431,18 @@ types:
           Succesfully retrieved consensus
         body:
           type: Consensus
-  /transactions/{shortid}:
+  /transactions/shortid/{shortid}:
     description: |
-      Fetches an existing transaction from a block within the blockchain, using a given shortID.
+      Fetches an existing transaction from a block within the blockchain, using a given shortID or regular ID.
+      If the regular ID is used, the short ID will be returned for future reference
     responses:
       200:
         description: |
           Succesfully retrieved transaction
         body:
-          type: Transaction
+          type: TransactionExternal
+          properties:
+            shortid?: string
       204:
         description: |
           Succesfully lookup, no transaction available for the given short ID

--- a/modules/consensus.go
+++ b/modules/consensus.go
@@ -139,6 +139,14 @@ type (
 		MaturityHeight types.BlockHeight
 	}
 
+	// TransactionIDDiff represents the addition or removal of a mapping between a transactions
+	// long ID ands its short ID
+	TransactionIDDiff struct {
+		Direction DiffDirection
+		LongID    types.TransactionID
+		ShortID   types.TransactionShortID
+	}
+
 	// A ConsensusSet accepts blocks and builds an understanding of network
 	// consensus.
 	ConsensusSet interface {
@@ -162,6 +170,11 @@ type (
 		// the blockchain, using a given shortID.
 		// If that transaction does not exist, false is returned.
 		TransactionAtShortID(shortID types.TransactionShortID) (types.Transaction, bool)
+
+		// TransactionAtID allows you to fetch a transaction from a block within
+		// the blockchain, using a given transaction ID. If that transaction
+		// does not exist, false is returned
+		TransactionAtID(types.TransactionID) (types.Transaction, types.TransactionShortID, bool)
 
 		// ChildTarget returns the target required to extend the current heaviest
 		// fork. This function is typically used by miners looking to extend the

--- a/modules/consensus/applytransaction.go
+++ b/modules/consensus/applytransaction.go
@@ -82,6 +82,17 @@ func applyBlockStakeOutputs(tx *bolt.Tx, pb *processedBlock, t types.Transaction
 	}
 }
 
+// applyTransactionIDMapping applies a transaction id mapping to the consensus set
+func applyTransactionIDMapping(tx *bolt.Tx, pb *processedBlock, t types.Transaction) {
+	tidmod := modules.TransactionIDDiff{
+		Direction: modules.DiffApply,
+		LongID:    t.ID(),
+		ShortID:   types.NewTransactionShortID(pb.Height, uint16(len(pb.TxIDDiffs))),
+	}
+	pb.TxIDDiffs = append(pb.TxIDDiffs, tidmod)
+	commitTxIDMapDiff(tx, tidmod, modules.DiffApply)
+}
+
 // applyTransaction applies the contents of a transaction to the ConsensusSet.
 // This produces a set of diffs, which are stored in the blockNode containing
 // the transaction. No verification is done by this function.
@@ -90,4 +101,5 @@ func applyTransaction(tx *bolt.Tx, pb *processedBlock, t types.Transaction) {
 	applyCoinOutputs(tx, pb, t)
 	applyBlockStakeInputs(tx, pb, t)
 	applyBlockStakeOutputs(tx, pb, t)
+	applyTransactionIDMapping(tx, pb, t)
 }

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -248,6 +248,24 @@ func (cs *ConsensusSet) TransactionAtShortID(shortID types.TransactionShortID) (
 	return block.Transactions[txSeqID], true
 }
 
+// TransactionAtID allows you to fetch a transaction from a block within the blockchain,
+// using a given transaction ID. If that transaction does not exist, false is returned
+func (cs *ConsensusSet) TransactionAtID(id types.TransactionID) (types.Transaction, types.TransactionShortID, bool) {
+	var txnShortID types.TransactionShortID
+	var exists bool
+	_ = cs.db.View(func(tx *bolt.Tx) error {
+		shortID, err := getTransactionShortID(tx, id)
+		if err != nil {
+			return err
+		}
+		txnShortID = shortID
+		return nil
+	})
+
+	txn, exists := cs.TransactionAtShortID(txnShortID)
+	return txn, txnShortID, exists
+}
+
 // ChildTarget returns the target for the child of a block.
 func (cs *ConsensusSet) ChildTarget(id types.BlockID) (target types.Target, exists bool) {
 	// A call to a closed database can cause undefined behavior.

--- a/modules/consensus/diffs.go
+++ b/modules/consensus/diffs.go
@@ -66,6 +66,15 @@ func commitBlockStakeOutputDiff(tx *bolt.Tx, sfod modules.BlockStakeOutputDiff, 
 	}
 }
 
+// commitTxIDMapDiff applies or reverts a transaction ID mapping diff
+func commitTxIDMapDiff(tx *bolt.Tx, tidmod modules.TransactionIDDiff, dir modules.DiffDirection) {
+	if tidmod.Direction == dir {
+		addTxnIDMapping(tx, tidmod.LongID, tidmod.ShortID)
+	} else {
+		removeTxnIDMapping(tx, tidmod.LongID)
+	}
+}
+
 // commitDelayedCoinOutputDiff applies or reverts a delayedCoinOutputDiff.
 func commitDelayedCoinOutputDiff(tx *bolt.Tx, dscod modules.DelayedCoinOutputDiff, dir modules.DiffDirection) {
 	if dscod.Direction == dir {

--- a/modules/consensus/processedblock.go
+++ b/modules/consensus/processedblock.go
@@ -34,6 +34,7 @@ type processedBlock struct {
 	CoinOutputDiffs        []modules.CoinOutputDiff
 	BlockStakeOutputDiffs  []modules.BlockStakeOutputDiff
 	DelayedCoinOutputDiffs []modules.DelayedCoinOutputDiff
+	TxIDDiffs              []modules.TransactionIDDiff
 
 	ConsensusChecksum crypto.Hash
 }

--- a/modules/wallet/wallet_test.go
+++ b/modules/wallet/wallet_test.go
@@ -401,6 +401,17 @@ func (css *consensusSetStub) TransactionAtShortID(shortID types.TransactionShort
 	return block.Transactions[txSeqID], true
 }
 
+func (css *consensusSetStub) TransactionAtID(id types.TransactionID) (types.Transaction, types.TransactionShortID, bool) {
+	for i, b := range css.blocks {
+		for j, t := range b.Transactions {
+			if t.ID() == id {
+				return t, types.NewTransactionShortID(types.BlockHeight(i), uint16(j)), true
+			}
+		}
+	}
+	return types.Transaction{}, 0, false
+}
+
 func (css *consensusSetStub) ChildTarget(id types.BlockID) (types.Target, bool) {
 	// TODO: return a more sensible value if required
 	return types.Target{}, false

--- a/pkg/client/consensuscmd.go
+++ b/pkg/client/consensuscmd.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"regexp"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -67,25 +66,19 @@ func EstimatedHeightAt(t time.Time) types.BlockHeight {
 }
 
 // Consensustransactioncmd is the handler for the command `rivinec consensus transaction`.
-// Prints the transaction found for the given shortID.
-func Consensustransactioncmd(shortID string) {
-	if !consensusShortIDRegexp.MatchString(shortID) {
-		Die("invalid shortID: ", shortID)
-	}
-
+// Prints the transaction found for the given id. If the ID is a long transaction ID, it also
+// prints the short transaction ID for future reference
+func Consensustransactioncmd(id string) {
 	var txn api.ConsensusGetTransaction
-	err := GetAPI("/consensus/transactions/"+shortID, &txn)
+
+	err := GetAPI("/consensus/transactions/"+id, &txn)
 	if err != nil {
-		Die("failed to get transaction: ", err, "; shortID: ", shortID)
+		Die("failed to get transaction:", err, "; ID:", id)
 	}
 
 	encoder := json.NewEncoder(os.Stdout)
 	err = encoder.Encode(txn)
 	if err != nil {
-		Die("failed to encode transaction: ", err, "; shortID: ", shortID)
+		Die("failed to encode transaction:", err, "; ID:", id)
 	}
 }
-
-var (
-	consensusShortIDRegexp = regexp.MustCompile("^[0-9]{1,8}$")
-)

--- a/types/transactions.go
+++ b/types/transactions.go
@@ -8,7 +8,6 @@ package types
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 
 	"github.com/rivine/rivine/crypto"
@@ -299,14 +298,19 @@ func (s *Specifier) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// MarshalJSON marshals an id as a hex string.
-func (tid TransactionID) MarshalJSON() ([]byte, error) {
-	return json.Marshal(tid.String())
-}
-
 // String prints the id in hex.
 func (tid TransactionID) String() string {
-	return fmt.Sprintf("%x", tid[:])
+	return crypto.Hash(tid).String()
+}
+
+// LoadString loads the given transaction ID from a hex string
+func (tid *TransactionID) LoadString(str string) error {
+	return (*crypto.Hash)(tid).LoadString(str)
+}
+
+// MarshalJSON marshals an id as a hex string.
+func (tid TransactionID) MarshalJSON() ([]byte, error) {
+	return crypto.Hash(tid).MarshalJSON()
 }
 
 // UnmarshalJSON decodes the json hex string of the id.
@@ -314,47 +318,62 @@ func (tid *TransactionID) UnmarshalJSON(b []byte) error {
 	return (*crypto.Hash)(tid).UnmarshalJSON(b)
 }
 
-// MarshalJSON marshals an id as a hex string.
-func (oid OutputID) MarshalJSON() ([]byte, error) {
-	return json.Marshal(oid.String())
-}
-
-// String prints the id in hex.
+// String prints the output id in hex.
 func (oid OutputID) String() string {
-	return fmt.Sprintf("%x", oid[:])
+	return crypto.Hash(oid).String()
 }
 
-// UnmarshalJSON decodes the json hex string of the id.
+// LoadString loads the given output id from a hex string
+func (oid *OutputID) LoadString(str string) error {
+	return (*crypto.Hash)(oid).LoadString(str)
+}
+
+// MarshalJSON marshals an output id as a hex string.
+func (oid OutputID) MarshalJSON() ([]byte, error) {
+	return crypto.Hash(oid).MarshalJSON()
+}
+
+// UnmarshalJSON decodes the json hex string of the output id.
 func (oid *OutputID) UnmarshalJSON(b []byte) error {
 	return (*crypto.Hash)(oid).UnmarshalJSON(b)
 }
 
-// MarshalJSON marshals an id as a hex string.
-func (scoid CoinOutputID) MarshalJSON() ([]byte, error) {
-	return json.Marshal(scoid.String())
+// String prints the coin output id in hex.
+func (coid CoinOutputID) String() string {
+	return crypto.Hash(coid).String()
 }
 
-// String prints the id in hex.
-func (scoid CoinOutputID) String() string {
-	return fmt.Sprintf("%x", scoid[:])
+// LoadString loads the given coin output id from a hex string
+func (coid *CoinOutputID) LoadString(str string) error {
+	return (*crypto.Hash)(coid).LoadString(str)
 }
 
-// UnmarshalJSON decodes the json hex string of the id.
-func (scoid *CoinOutputID) UnmarshalJSON(b []byte) error {
-	return (*crypto.Hash)(scoid).UnmarshalJSON(b)
+// MarshalJSON marshals an coin output id as a hex string.
+func (coid CoinOutputID) MarshalJSON() ([]byte, error) {
+	return crypto.Hash(coid).MarshalJSON()
 }
 
-// MarshalJSON marshals an id as a hex string.
-func (bsoid BlockStakeOutputID) MarshalJSON() ([]byte, error) {
-	return json.Marshal(bsoid.String())
+// UnmarshalJSON decodes the json hex string of the coin output id.
+func (coid *CoinOutputID) UnmarshalJSON(b []byte) error {
+	return (*crypto.Hash)(coid).UnmarshalJSON(b)
 }
 
-// String prints the id in hex.
+// String prints the blockstake output id in hex.
 func (bsoid BlockStakeOutputID) String() string {
-	return fmt.Sprintf("%x", bsoid[:])
+	return crypto.Hash(bsoid).String()
 }
 
-// UnmarshalJSON decodes the json hex string of the id.
+// LoadString loads the given blockstake output id from a hex string
+func (bsoid *BlockStakeOutputID) LoadString(str string) error {
+	return (*crypto.Hash)(bsoid).LoadString(str)
+}
+
+// MarshalJSON marshals an blockstake output id as a hex string.
+func (bsoid BlockStakeOutputID) MarshalJSON() ([]byte, error) {
+	return crypto.Hash(bsoid).MarshalJSON()
+}
+
+// UnmarshalJSON decodes the json hex string of the blockstake output id.
 func (bsoid *BlockStakeOutputID) UnmarshalJSON(b []byte) error {
 	return (*crypto.Hash)(bsoid).UnmarshalJSON(b)
 }

--- a/types/transactions_test.go
+++ b/types/transactions_test.go
@@ -1,7 +1,10 @@
 package types
 
 import (
+	"crypto/rand"
 	"encoding/json"
+	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/rivine/rivine/crypto"
@@ -109,4 +112,89 @@ func TestTransactionShortID(t *testing.T) {
 			t.Errorf("transaction seq ID (%v) != %v", tsid, testCase.TxSequenceID)
 		}
 	}
+}
+
+func TestOutputIDStringJSONEncoding(t *testing.T) {
+	testIDStringJSONEncoding(t, func(h *[crypto.HashSize]byte) idEncoder {
+		if h == nil {
+			return new(OutputID)
+		}
+		return (*OutputID)(h)
+	})
+}
+
+func TestTransactionIDStringJSONEncoding(t *testing.T) {
+	testIDStringJSONEncoding(t, func(h *[crypto.HashSize]byte) idEncoder {
+		if h == nil {
+			return new(TransactionID)
+		}
+		return (*TransactionID)(h)
+	})
+}
+
+func TestCoinOutputIDStringJSONEncoding(t *testing.T) {
+	testIDStringJSONEncoding(t, func(h *[crypto.HashSize]byte) idEncoder {
+		if h == nil {
+			return new(CoinOutputID)
+		}
+		return (*CoinOutputID)(h)
+	})
+}
+
+func TestBlockStakeOutputIDStringJSONEncoding(t *testing.T) {
+	testIDStringJSONEncoding(t, func(h *[crypto.HashSize]byte) idEncoder {
+		if h == nil {
+			return new(BlockStakeOutputID)
+		}
+		return (*BlockStakeOutputID)(h)
+	})
+}
+
+func testIDStringJSONEncoding(t *testing.T, f func(*[crypto.HashSize]byte) idEncoder) {
+	for i := 0; i < 128; i++ {
+		// generate fresh id
+		var s [crypto.HashSize]byte
+		rand.Read(s[:])
+		inputID := f(&s)
+
+		// test string encoding
+		str := inputID.String()
+		if len(str) == 0 {
+			t.Errorf("#%d: string length is 0", i)
+			continue
+		}
+		outputID := f(nil)
+		err := outputID.LoadString(str)
+		if err != nil {
+			t.Error(i, err)
+			continue
+		}
+		if !reflect.DeepEqual(inputID, outputID) {
+			t.Errorf("%d => %v != %v", i, inputID, outputID)
+		}
+
+		// test JSON encoding
+		bs, err := inputID.MarshalJSON()
+		if err != nil {
+			t.Error(i, err)
+			continue
+		}
+		outputID = f(nil)
+		err = outputID.UnmarshalJSON(bs)
+		if err != nil {
+			t.Error(i, err)
+			continue
+		}
+		if !reflect.DeepEqual(inputID, outputID) {
+			t.Errorf("%d => %v != %v", i, inputID, outputID)
+		}
+	}
+}
+
+type idEncoder interface {
+	json.Marshaler
+	json.Unmarshaler
+
+	fmt.Stringer
+	LoadString(string) error
 }


### PR DESCRIPTION
Allow lookup of a transaction using is regular/long ID
Remove explorer module dependency when doing a transaction lookup, the returned value is now the raw transaction, not the explorer module transaction

Closes #182 
Closes #188 
Closes #204 