### PR TITLE
build examples on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,3 +40,13 @@ jobs:
       script:
         - make test-long
         - make ineffassign
+    - stage: test
+      language: go
+      go: 1.8.x
+      script:
+        - go build -o /dev/null ./doc/examples/offline_transaction
+    - stage: test
+      language: go
+      go: tip
+      script:
+        - go build -o /dev/null ./doc/examples/offline_transaction


### PR DESCRIPTION
this ensures that examples remain buildable,
it doesn't proof they are functional (as in logical 100% good),
but at least it will help us to remind to keep the examples up to date with the code base

closes #109