### PR TITLE
add version when installing using a supported make target

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -7,8 +7,16 @@ set -e
 
 # version is supplied as argument
 package="github.com/rivine/rivine"
-full_version=$(git describe | cut -d '-' -f 1,3)
-version=$(echo "$full_version" | cut -d '-' -f 1)
+
+
+version="$(git describe | cut -d '-' -f 1)"
+commit="$(git rev-parse --short HEAD)"
+if [ "$commit" == "$(git rev-list -n 1 $version | cut -c1-7)" ]
+then
+	full_version="$version"
+else
+	full_version="${version}-${commit}"
+fi
 
 for os in darwin linux windows; do
 	echo Packaging ${os}...
@@ -22,7 +30,7 @@ for os in darwin linux windows; do
 		if [ "$os" == "windows" ]; then
 			bin=${pkg}.exe
 		fi
-		GOOS=${os} go build -a -tags 'netgo' \
+		GOOS=${os} go build -a \
 			-ldflags="-X ${package}/build.rawVersion=${full_version} -s -w" \
 			-o "${folder}/${bin}" "./${pkg}"
 


### PR DESCRIPTION
fixes #282 

result

```
$ git checkout v1.0.2 && hack_makefile() && make release-std
go build -ldflags '-X github.com/rivine/rivine/build.rawVersion=v1.0.2' -o /Users/glendc/go/bin/rivined ./cmd/rivined
go build -ldflags '-X github.com/rivine/rivine/build.rawVersion=v1.0.2' -o /Users/glendc/go/bin/rivinec ./cmd/rivinec
$ rivined version
Rivine Daemon v1.0.2
Rivine Protocol v1.0.2
```

> version only contains tag when exactly on the tag (e.g. `v1.0.2`)

```
$ git checkout master && make release-std
go build -ldflags '-X github.com/rivine/rivine/build.rawVersion=v1.0.2-bdfee0f' -o /Users/glendc/go/bin/rivined ./cmd/rivined
go build -ldflags '-X github.com/rivine/rivine/build.rawVersion=v1.0.2-bdfee0f' -o /Users/glendc/go/bin/rivinec ./cmd/rivinec
$ rivined version
Rivine Daemon v1.0.2-bdfee0f
Rivine Protocol v1.0.2-bdfee0f
```

> version contains both commit and tag when passed a tag (e.g. `v1.0.2-bdfee0f`)