### PR TITLE
remove support for unknown versions

### DIFF
--- a/types/signatures.go
+++ b/types/signatures.go
@@ -20,13 +20,9 @@ import (
 
 var (
 	// These Specifiers enumerate the types of signatures that are recognized
-	// by this implementation. If a signature's type is unrecognized, the
-	// signature is treated as valid. Signatures using the special "entropy"
-	// type are always treated as invalid; see Consensus.md for more details.
-	SignatureEntropy = Specifier{'e', 'n', 't', 'r', 'o', 'p', 'y'}
+	// by this implementation. see Consensus.md for more details.
 	SignatureEd25519 = Specifier{'e', 'd', '2', '5', '5', '1', '9'}
 
-	ErrEntropyKey                = errors.New("transaction tries to use an entproy public key")
 	ErrFrivolousSignature        = errors.New("transaction contains a frivolous signature")
 	ErrInvalidPubKeyIndex        = errors.New("transaction contains a signature that points to a nonexistent public key")
 	ErrInvalidUnlockHashChecksum = errors.New("provided unlock hash has an invalid checksum")

--- a/types/transaction_controller.go
+++ b/types/transaction_controller.go
@@ -130,94 +130,9 @@ func (td *TransactionData) UnmarshalSia(r io.Reader) error {
 
 // Standard Transaction Controller implementations
 type (
-	// UnknownTransactionController is the transaction controller used,
-	// for all transaction versions which aren't registered.
-	UnknownTransactionController struct{}
-
 	// DefaultTransactionController is the default transaction controller used,
 	// and is also by default the controller for the default transaction version 0x01.
 	DefaultTransactionController struct{}
-)
-
-// EncodeTransactionData implements TransactionController.EncodeTransactionData
-func (utc UnknownTransactionController) EncodeTransactionData(td TransactionData) ([]byte, error) {
-	rawData, ok := td.Extension.([]byte)
-	if !ok {
-		return nil, ErrUnexpectedExtensionType
-	}
-	if build.DEBUG {
-		err := utc.debugEncodeTransactionCheck(td)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return rawData, nil
-}
-
-// DecodeTransactionData implements TransactionController.DecodeTransactionData
-func (utc UnknownTransactionController) DecodeTransactionData(b []byte) (TransactionData, error) {
-	return TransactionData{Extension: b}, nil
-}
-
-// JSONEncodeTransactionData implements TransactionController.JSONEncodeTransactionData
-func (utc UnknownTransactionController) JSONEncodeTransactionData(td TransactionData) ([]byte, error) {
-	rawData, ok := td.Extension.([]byte)
-	if !ok {
-		return nil, ErrUnexpectedExtensionType
-	}
-	if build.DEBUG {
-		err := utc.debugEncodeTransactionCheck(td)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return json.Marshal(rawData)
-}
-
-// JSONDecodeTransactionData implements TransactionController.JSONDecodeTransactionData
-func (utc UnknownTransactionController) JSONDecodeTransactionData([]byte) (TransactionData, error) {
-	return TransactionData{}, ErrInvalidTransactionVersion
-}
-
-// ValidateTransaction implements TransactionValidator.ValidateTransaction
-func (utc UnknownTransactionController) ValidateTransaction(Transaction, uint64) error {
-	return ErrInvalidTransactionVersion
-}
-
-// InputSigHash implements InputSigHasher.InputSigHash
-func (utc UnknownTransactionController) InputSigHash(Transaction, uint64, ...interface{}) crypto.Hash {
-	if build.DEBUG {
-		panic(ErrInvalidTransactionVersion)
-	}
-	return crypto.Hash{}
-}
-
-func (utc UnknownTransactionController) debugEncodeTransactionCheck(td TransactionData) error {
-	if len(td.CoinInputs) != 0 {
-		return errors.New("no coin inputs should be defined for a transaction with an unknown version number")
-	}
-	if len(td.CoinOutputs) != 0 {
-		return errors.New("no coin outputs should be defined for a transaction with an unknown version number")
-	}
-	if len(td.BlockStakeInputs) != 0 {
-		return errors.New("no block stake inputs should be defined for a transaction with an unknown version number")
-	}
-	if len(td.BlockStakeOutputs) != 0 {
-		return errors.New("no block stake outputs should be defined for a transaction with an unknown version number")
-	}
-	if len(td.MinerFees) != 0 {
-		return errors.New("no miner fees should be defined for a transaction with an unknown version number")
-	}
-	if len(td.ArbitraryData) != 0 {
-		return errors.New("no arbitrary data should be defined for a transaction with an unknown version number")
-	}
-	return nil
-}
-
-// optional interfaces the UnknownTransactionController implements
-var (
-	_ TransactionValidator = UnknownTransactionController{}
-	_ InputSigHasher       = UnknownTransactionController{}
 )
 
 // EncodeTransactionData implements TransactionController.EncodeTransactionData

--- a/types/transactions.go
+++ b/types/transactions.go
@@ -152,6 +152,10 @@ type (
 	}
 )
 
+var (
+	ErrUnknownTransactionType = errors.New("unknown transaction type")
+)
+
 // ID returns the id of a transaction, which is taken by marshalling all of the
 // fields except for the signatures and taking the hash of the result.
 func (t Transaction) ID() (id TransactionID) {
@@ -250,7 +254,7 @@ func (t Transaction) MarshalSia(w io.Writer) error {
 	// get a controller registered or unknown controller
 	controller, exists := _RegisteredTransactionVersions[t.Version]
 	if !exists {
-		controller = UnknownTransactionController{}
+		return ErrUnknownTransactionType
 	}
 
 	// encode the data using the controller,
@@ -296,7 +300,7 @@ func (t *Transaction) UnmarshalSia(r io.Reader) error {
 	}
 	controller, exists := _RegisteredTransactionVersions[t.Version]
 	if !exists {
-		controller = UnknownTransactionController{}
+		return ErrUnknownTransactionType
 	}
 	td, err := controller.DecodeTransactionData(rawData)
 	if err != nil {
@@ -342,7 +346,7 @@ func (t Transaction) MarshalJSON() ([]byte, error) {
 	// get a controller registered or unknown controller
 	controller, exists := _RegisteredTransactionVersions[t.Version]
 	if !exists {
-		controller = UnknownTransactionController{}
+		return nil, ErrUnknownTransactionType
 	}
 
 	// json-encode the data using the controller,
@@ -381,7 +385,7 @@ func (t *Transaction) UnmarshalJSON(b []byte) error {
 	}
 	controller, exists := _RegisteredTransactionVersions[txn.Version]
 	if !exists {
-		controller = UnknownTransactionController{}
+		return ErrUnknownTransactionType
 	}
 	td, err := controller.JSONDecodeTransactionData(txn.Data)
 	if err != nil {


### PR DESCRIPTION
closes #293

Unknown versions of transactions, conditions and fulfillments
can no longer be decoded, as these are no longer supported.

The only way to add a new/alternative txn/condition/fulfillment
is to ensure the majority of block stake holders has this update
and agrees with it.