### PR TITLE
update transaction docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Building From Source
 To build from source, [Go 1.8 or higher must be installed](https://golang.org/doc/install)
 on the system (older versions of GO might work, but we don't support it). Then simply use `go get`:
 
-```
+```bash
 go get -u github.com/rivine/rivine/cmd/...
 ```
 
@@ -48,6 +48,14 @@ to build and `docker run --name rivine rivine` to start the daemon.
 Running the client can be done with `docker run -it rivine rivinec`.
 Add client commands just like you would calling rivinec normally (like `docker run -it rivine rivinec wallet transactions`).
 
+Supporting a Rivine Wallet in a Light Client
+--------------------
+
+Should you wish to support Rivine, or more likely a Rivine-based wallet in a(n) existing/new **light** client,
+it is recommended that you read [/doc/transactions/light_wallet.md](/doc/transactions/light_wallet.md) as a starting point.
+
+This document references to (most of the) other documentation
+you'll need in order to develop your own light wallet for a Rivine-Protocol-based blockchain.
 
 Troubleshooting
 ---------------

--- a/doc/transactions/light_wallet.md
+++ b/doc/transactions/light_wallet.md
@@ -1,0 +1,219 @@
+# Light Wallet
+
+In the context of Rivine, we consider a light wallet to be a wallet which is managed using a light client.
+A light client has no local daemon running and instead relies on a remote daemon.
+This daemon could be one publicly available, such as standard explorer nodes,
+but it could also be a private one.
+
+These types of wallets are called light, because they don't do any validation or
+other heavy-lifting processing. Such wallets also do not store all blocks,
+and instead just process, and optionally store, the data that is relevant to the wallet.
+Making these types of wallets light in terms of both processing as well as storage,
+making them ideal for mobile wallets. It does however mean that trust is to be placed
+in the remote daemon(s) used.
+
+This document is to be used as a reference document,
+explaining all you need in order to add support for a Rivine wallet,
+to your light client.
+
+## Key Pairs
+
+A wallet is identified by one or multiple private keys. Each private key is linked to a public key.
+The public key is used to generate a wallet address, and thus a wallet can have multiple addresses,
+as many as there are private-public key pairs.
+
+All private keys of a single wallet are generated using the same seed,
+that seed should be backed up by the user as to be able to recover the wallet
+at any time, or even have multiple wallets using the same seed.
+
+> In the standard Rivine CLI Wallet a [blake2b][blake2b] checksum is generated using
+> the seed and the key (integral) index as input.
+> This checksum (32 bytes) is used as the entropy for the generation of
+> a [Ed25519][ed25519] private-public key pair.
+
+The [Ed25519][ed25519] signature algorithm is the only algorithm currently supported by
+the Rivine Protocol, for signatures provides as part of an input (spending an unspent output).
+This means that the public keys of your wallet have to have a size of 32 bytes,
+and the private keys (from which the public keys are derived)
+have to have a size of 64 bytes. The produced signatures will have a size of 64 bytes as well.
+
+> (!) Your wallet won't work if your public-private key pairs
+> aren't [Ed25519][ed25519]-compatible !!!
+
+In Rivine we use [BIP-39][bip39] to generate 24-word mnemonics from a seed,
+and go back from such a mnemonic to such a seed. The 24-word count mentioned before,
+means we expect random seeds of 32 bytes. This because of the assumption that it is easier
+for humans to communicate and remember words, rather than 32 random hexadecimal characters.
+
+Your wallet does not need to support [BIP-39][bip39], nor do your seeds need to be 32 bytes
+in order to be compatible with the Rivine Protocol. We do however recommend that you
+to support both these optional requirements, as to allow your users to use other wallet
+implementations should they wish to do so.
+
+## Creating Transactions
+
+Creating a transaction is done so by assembling a transaction, encoding it in the JSON format and
+passing it as the body in a POST call to the remote daemon using its REST API:
+
+```plain
+POST <daemon_addr>/transactionpool/transactions
+```
+
+> Note that this does mean that the remote daemon has to have the `Transaction Pool` module (`t`) enabled.
+> See the CLI daemon's `modules` command for more information.
+
+In order for your wallet to support this feature, you'll have to ensure that you can:
+
++ encode transactions in JSON format (see [/doc/transactions/transaction.md#json-encoding][jsonenc]);
++ create a signature for each input (see [the Signing Transactions chapter](#signing-transactions));
++ get all unspend outputs, as to be able to fund your transaction (see [the Getting Transactions chapter](#getting-transactions));
+
+When your (light) wallet supports this feature, you'll users will be able to:
+
++ send coins;
++ send block stakes;
++ put arbitrary data on the blockchain;
+
+If the POST call to that REST endpoint returns `200 OK`, it should mean that it was added to the transaction pool,
+it does however not mean that it will actually end up on the blockchain, certainly not immediately.
+
+### Signing Transactions
+
+As discussed before, signatures are created using the [Ed25519][ed25519] signature algorithm.
+This algorithm requires a hash as input. The hash (generated using [the blake2b 256 bit algorithm][blake2b])
+uses as input the binary encoding of most of the properties of a transaction.
+
+Therefore in order to be able to sign transactions you'll have to be able to:
+
++ Create a hash using [the blake2b (256 bit) algorithm][blake2b] (libraries are usually available to do this for you);
++ Binary-encode all necessary properties (see [/doc/transactions/transaction.md#binary-encoding][binenc]);
++ Convert raw binary data into a hex-encoded string (required as the [JSON-encoded][jsonenc] form of a signature is a hex-encoded string);
+
+One or multiple signatures are required per fulfillment, which becomes an input when paired with a ParentID (the ID of an unspent output).
+These fields are always labeled as `signature` (in singular or plural form). See the [JSON-encoding][jsonenc] for more information.
+
+Without the ability to sign transactions, your wallet will not be able to [create transactions](#Creating Transactions).
+
+### Example
+
+You can find example code, labeled "offline transaction",
+in [/doc/examples/offline_transaction/offline_transaction.go](/doc/examples/offline_transaction/offline_transaction.go).
+
+This example demonstrates how one can prepare a transaction manually,
+sign all inputs and finally create it using the POST call to `/transactionpool/transactions`.
+
+It is the only example implementation bundled with this codebase.
+As it is written in Golang and makes use of the Rivine library code,
+it does mean that not everything in this example is implemented from scratch,
+so you'll have to read parts of the Rivine codebase as well
+if you want to understand this offline transaction example in its full scope.
+
+## Getting Transactions
+
+A wallet (identified by a seed), can have one or multiple addresses. That we already know.
+Getting all transactions linked to one address can be done using the REST API of the remote daemon:
+
+```plain
+GET <daemon_addr>/explorer/hashes/<address>
+```
+
+> Note that this does mean that the remote daemon has to have the `Explorer` module (`e`) enabled.
+> See the CLI daemon's `modules` command for more information.
+
+It will give you response using the following JSON structure:
+
+```javascript
+{
+    "hashtype": "unlockhash",   // should always be the value "unlockhash"
+    "block": block,             // block structure can be ignored
+    /////////////////////////////////////////////////////////////////////////////////////
+    "blocks": [explorerBlock1, explorerBlock2, ...],
+    /////////////////////////////////////////////////////////////////////////////////////
+    "transaction": explorerTxn, // explorer transaction can be ignored as well
+    /////////////////////////////////////////////////////////////////////////////////////
+    "transactions": [explorerTxn1, explorerTxn2, ...],
+}
+
+// where each explorerTxnN is structured as follows:
+{
+    "id": id,                     // the id of the txn
+    "height": uint64,             // height of the block this txn belongs to
+    "parent": string,             // id of the block this txn belongs to
+    /////////////////////////////////////////////////////////////////////////////////////
+    "rawtransaction": txn,        // SEE /doc/transactions/transaction.md#json-encoding
+                                  // to know how this transaction is encoded
+    /////////////////////////////////////////////////////////////////////////////////////
+    "hextransaction": hextxn,     // can be ignored for this purpose
+    "coininputoutputs": io,       // can be ignored for this purpose
+    /////////////////////////////////////////////////////////////////////////////////////
+    // contains all ids of the coin outputs as found in the rawtransaction (using the same order).
+    // if the outputid is the parentID of a coin input of any of the returned transactions,
+    // it should be assumed the coin output is already spend, which can only happen once.
+    "coinoutputids": [id1, id2, ...],
+    /////////////////////////////////////////////////////////////////////////////////////
+    "blockstakeinputoutputs": io, // can be ignored for this purpose
+    /////////////////////////////////////////////////////////////////////////////////////
+    // contains all ids of the block stake outputs as found in the rawtransaction (using the same order).
+    // if the outputid is the parentID of a block stake input of any of the returned transactions,
+    // it should be assumed the block stake output is already spend, which can only happen once.
+    "blockstakeoutputids": ids,
+}
+// and where each explorerBlockN is structured as follows:
+{
+    "minerpayoutids": ids,        // can be ignored for this purpose
+    "transactions": txns,         // can be ignored for this purpose
+    /////////////////////////////////////////////////////////////////////////////////////
+    "rawblock": block,            // SEE /doc/transactions/transaction.md#json-encoding
+                                  // to know how this block is encoded
+    /////////////////////////////////////////////////////////////////////////////////////
+    "hexblock": string,           // can be ignored for this purpose
+    // ... block facts properties, which also can be ignored for this purpose
+}
+```
+
+Should your wallet support multiple addresses per seed,
+you'll need to merge the results for all addresses together,
+in order to find the complete information for that wallet.
+
+### Getting Unconfirmed Transactions
+
+When a transaction isn't part of a block yet,
+it should exist in the transaction pool of the remote daemon.
+The transaction pool is the pool of transactions which the daemon uses
+as input in order to create a block. This pool can be filled both by the daemon
+itself (using its REST API), as well as by peers (other daemons) it is connected to.
+
+You can get all transactions in the transaction pool of a remote daemon using its REST API:
+
+```plain
+GET <daemon_addr>/transactionpool/transactions
+```
+
+> Note that this does mean that the remote daemon has to have the `Transaction Pool` module (`t`) enabled.
+> See the CLI daemon's `modules` command for more information.
+
+It will give you response using the following JSON structure:
+
+```javascript
+{
+    // SEE /doc/transactions/transaction.md#json-encoding
+    // to know how each txnN transaction is encoded
+    "transactions": [txn1, txn2],
+}
+```
+
+You'll have to filter the outputs and inputs using the address(es) of the wallet you're checking for,
+let's call that wallet A. Each output targeted for wallet A means your unconfirmed balance gets increased,
+while each input funded by wallet A (which can be known by tracing the parentID of each input)
+means your unconfirmed balance gets decreased.
+
+If you aim to be efficient in resources (including time) you should already have a mapping
+of all unspent outputs by the time you call this function,
+this way you can easily check if the input's parentID belongs to any of the unspent outputs of wallet A.
+
+[bip39]: https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki
+[Ed25519]: https://tools.ietf.org/html/rfc8032#section-5.1
+[blake2b]: https://blake2.net
+
+[jsonenc]: /doc/transactions/transaction.md#json-encoding
+[binenc]: /doc/transactions/transaction.md#binary-encoding

--- a/doc/transactions/transaction.md
+++ b/doc/transactions/transaction.md
@@ -8,7 +8,7 @@ which haven't been used as input yet. The same goes for block stakes, another ki
 In order to create/send a transaction, one has to pay a transaction fee. These are registered
 as part of a transaction and labeled as "Miner Fees". It is important to note that the total sum
 of coin inputs MUST be equal to the total sum of coin outs and miner fees combined.
-Block stakes are a seperate asset, where the total sum of block stake inputs must
+Block stakes are a separate asset, where the total sum of block stake inputs must
 simply be equal to the total sum of block stake outputs.
 
 As each output is backed by one or multiple inputs, it is not uncommon to have a too big
@@ -16,12 +16,26 @@ amount of input registered. If so, it is the convention to simply register the e
 amount as another output, but this time addressed to your own wallet.
 This works very similar to change money you get in a supermarket by paying too much.
 
-Besides the inputs, outputs and minerfees, one can also optionally attach some arbtirary binary
-data to a transaction, which isn't of any meaning to the blockchain itself.
+Each transaction needs to have sufficient Miner Fees as well as coin input(s) to back these fees up.
+The rest of the requirements and structure of a transaction depends upon the version of that transaction.
 
-Should you read this document as part of an effort of developing your own light wallet client
-that supports a rivine-based blockchain, you might also want to checkout
-[the offline transaction example](/doc/examples/offline_transaction/offline_transaction.go).
+## Versions
+
+Each transaction has a version, which is to be decoded as the very first step.
+Knowing the version, it can be deduced how to decode the rest of the data, if possible at all.
+
+At the time of writing there are only two versions, `0x00` (0) and `0x01` (1).
+Version 1 deprecates version 0, which is now considered legacy.
+While version 0 is still accepted, it is no longer recommended.
+
+Versions do however not always need to replace previous versions.
+One other use case of versions could be to provide the option to have alternative
+transaction structures, requiring their own requirements, validation and encoding.
+
+Such alternative transactions are however up to blockchains to be implemented using the Rivine protocol,
+(using the [`RegisterTransactionVersion`](https://godoc.org/github.com/rivine/rivine/types#RegisterTransactionVersion))
+as Rivine keeps it at the v0 and v1 transactions for now,
+which are only to be used for coin/blockstake transfers, optionally wth some (limited) Arbitrary Data attached to it.
 
 ## Relevant Source Files
 
@@ -29,30 +43,50 @@ For those interested, this document explains logic
 implemented in the Golang reference Rivine implementation, and covers following source files:
 
 + [/types/transactions.go](/types/transactions.go)
-+ [/types/inputlock.go](/types/inputlock.go)
++ [/types/unlockcondition.go](/types/unlockcondition.go)
 + [/types/unlockhash.go](/types/unlockhash.go)
 + [/types/signatures.go](/types/signatures.go)
 + [/types/currency.go](/types/currency.go)
 + [/types/timestamp.go](/types/timestamp.go)
 
 The master version of the (public) Golang documentation for
-the module of these files can be found at: https://godoc.org/github.com/rivine/rivine/types
+the module of these files can be found at: <https://godoc.org/github.com/rivine/rivine/types>
 
-## Send coins
+> Should you have Rivine cloned onto a Golang-enabled machine available to you,
+> you can render the same godoc information for whatever version you wish (after checking it out using `git checkout`),
+> by running `godoc -http=:6060` in your terminal, after which you should be able to browse to the go documentation
+> of your locally checked out Rivine version at: <http://localhost:6060/pkg/github.com/rivine/rivine/>,
+> making the types module documentation available at: <http://localhost:6060/pkg/github.com/rivine/rivine/types>
 
-Send coins from 0x78e6... to 0x1d64..
+## Index
 
-// TODO: Diagram
++ Logic and rules of normal transactions:
+  + [Send coins](#send-coins): explains a bit about the process of sending coins
+  + [Arbitrary data](#arbitrary-data): explains a bit about what arbitrary data is and its limits
+  + [Double Spend Rules](#double-spend-rules): explains a bit about how double spending is prevented
++ [JSON Encoding](#json-encoding):
+  + [Introduction to JSON encoding](#introduction-to-json-encoding): why json encoding, when is it used
+  + [JSON Encoding of Types](#json-encoding-of-types): explains how all parts of a transactions are JSON encoded
+  + [JSON encoding of a v1 Transaction](#json-encoding-of-v1-transactions): a full and detailed example of a JSON-encoded v1 transaction
+  + [JSON encoding of a v0 Transaction](#json-encoding-of-v0-transactions): a full and detailed example of a JSON-encoded v0 transaction
++ [Binary Encoding](#binary-encoding):
+  + [Introduction to Binary Encoding](#introduction-to-binary-encoding): why binary encoding, when is it used
+  + [Binary Encoding of Types](#binary-encoding-of-types): explains how all parts of a transactions are binary encoded
+  + [Binary encoding of a v1 Transaction](#binary-encoding-of-v1-transactions): a full and detailed example of a binary-encoded v1 transaction
+  + [Binary encoding of a v0 Transaction](#binary-encoding-of-v0-transactions): a full and detailed example of a binary-encoded v0 transaction
++ [Signing Transactions](#signing-transactions):
+  + [Introduction to Signing Transactions](#introduction-to-signing-transaction)
+  + [Signing a v1 Transaction](#signing-a-v1-transaction): explains how inputs are signed in v1 transactions
+  + [Signing a v0 Transaction](#signing-a-v0-transaction): explains how inputs are signed in v0 transactions
 
-When spending money you need to add a coininput in a transaction, info needed in coininput is:
-1. ParentID is the ID of the unspend coinoutput (UTXO)
-2. Recalculate the unlockconditions that generates the unlockhash (normally they are standard and can be reconstructed)
-3. Use the corresponding private key to sign a transactionSignature.
-4. The money that can be spent in the transaction is found in the corresponding coinoutput. ex. Value = 2000
+## Logic and rules of normal transactions
 
-Per transaction: The sum of all values in coinoutput should be less than the sum of all "unlocked" values in the coininput. The difference is minerfee for the the block generator.
+This list is not an exclusive list, and some rules might be missing.
+Regarding the logic and rules of normal transactions, please only
+use the Golang codebase of Rivine as the only true documentation
+about logic and rules of normal transactions.
 
-## Arbitrary data
+### Arbitrary data
 
 Arbitrary Data can be of any size. There is however a size limit on a Transaction and a block.
 Keep in mind that the fee is depending on the size of a transaction, a blockcreator can ignore to add a transaction with small fees for a lot of small transactions with a summed up bigger fee (opportune).
@@ -62,7 +96,7 @@ protocols sit on top of Rivine. The arbitrary data can also be used for soft
 forks, and for protocol relevant information. Any arbitrary data is allowed by
 the consensus.
 
-## Double Spend Rules
+### Double Spend Rules
 
 When two conflicting transactions are seen, the first transaction is the only
 one that is kept. If the blockchain reorganizes, the transaction that is kept
@@ -76,269 +110,817 @@ certain minimum. For the near future, there are no plans to prioritize
 transactions with substantially higher fees. Other mining software may take
 alternative approaches.
 
-## Format
+## JSON Encoding
 
-As always, there are 2 formats. The binary format and the text/json format.
-The binary format is used as part of the rivine protocol, when encoding transactions between gateways,
-while the text (JSON) encoding is used for storage as well as part of the daemon's REST API (e.g. `/transactionpool/transactions`).
+### Introduction to JSON encoding
 
-### Text Format
+JSON encoding is used as the encoding protocol for any data that leaves and enters the daemon via the REST API.
 
-The text format is done using JSON encoding,
-where binary values (byte slices) are usually encoded in a hex-format,
-except for arbitrary data, which is base64-encoded.
-
-The text (JSON) format can be explained best using an example:
+A Transaction, no matter the version, is always JSON-encoded as follows:
 
 ```javascript
 {
-	"version": 0, // version ID, byte, for now always `0`, optional
-	"data": { // actual transaction, required
-		"coininputs": [ // coin inputs, at least 1 element required
-			{
-				// coin output ID, crypto hash (blake2b, 256 bit), required, hex-encoded
-				"parentid": "abcdef012345abcdef012345abcdef012345abcdef012345abcdef012345abcd",
-				// input lock, required
-				"unlocker": {
-					"type": 1, 	// input lock, byte, supported range: [1,2], unknown range: [3,255], required
-											// `1` = SingleSignature, `2` = AtomicSwap
-					"condition": { // unlock condition, required, format dependend upon sibling "type" property
-						// public key, required, format: `<algorithmSpecifier>:<key>`, where <key> is hex-encoded
-						// and which byte-size is fixed but dependend upon the <algorithmSpecifier>,
-						// <algorithmSpecifier> can currently only be `"ed25519"`
-						"publickey": "ed25519:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-					},
-					"fulfillment": { 	// unlock fulfillment, fulfills the unlock condition, required,
-														// format dependend upon sibling "type" property
-						// signature, byte-size is fixed but dependend upon the <algorithmSpecifier>,
-						// when <algorithmSpecifier> equals `"ed25519"` the byte size is 64, required, hex-encoded
-						"signature": "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefab"
-					}
-				}
-			},
-			{
-				// coin output ID, crypto hash (blake2b, 256 bit), required, hex-encoded
-				"parentid": "012345defabc012345defabc012345defabc012345defabc012345defabc0123",
-				// input lock, required
-				"unlocker": {
-					"type": 2, 	// input lock, byte, supported range: [1,2], unknown range: [3,255], required
-											// `1` = SingleSignature, `2` = AtomicSwap
-					"condition": { // unlock condition, required, format dependend upon sibling "type" property
-						// sender's unlock hash, required, hex-encoded, fixed-size
-						"sender": "0101234567890123456789012345678901012345678901234567890123456789018a50e31447b8",
-						// receiver's unlock hash, required, hex-encoded, fixed-size
-						"receiver": "01abc0123abc0123abc0123abc0123abc0abc0123abc0123abc0123abc0123abc057382370c8d9",
-						// hashed secret, fixed size, 32 bytes, hex-encoded, sha256(secret)
-						"hashedsecret": "abc543defabc543defabc543defabc543defabc543defabc543defabc543defa",
-						// time lock, unix epoch timestamp (in seconds), 64-bit unsigned integer, required
-						"timelock": 1522068743
-					},
-					"fulfillment": { 	// unlock fulfillment, fulfills the unlock condition, required,
-														// format dependend upon sibling "type" property
-						// public key, required, format: `<algorithmSpecifier>:<key>`, where <key> is hex-encoded
-						// and which byte-size is fixed but dependend upon the <algorithmSpecifier>,
-						// <algorithmSpecifier> can currently only be `"ed25519"`
-						"publickey": "ed25519:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-						// signature, byte-size is fixed but dependend upon the <algorithmSpecifier>,
-						// when <algorithmSpecifier> equals `"ed25519"` the byte size is 64, required, hex-encoded
-						"signature": "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefab",
-						// secret, fixed size, 32 bytes, hex-encoded
-						"secret": "def789def789def789def789def789dedef789def789def789def789def789de"
-					}
-				}
-			}
-		],
-		"coinoutputs": [ // coin outputs, optional
-			{
-				"value": "3", // currency value (in smallest unit), big integer as string, required, positive
-				// output's unlock hash, specifier output will belocked to that hash, could represent wallet
-				"unlockhash": "0101234567890123456789012345678901012345678901234567890123456789018a50e31447b8"
-			},
-			{
-				"value": "5", // currency value (in smallest unit), big integer as string, required, positive
-				// output's unlock hash, specifier output will belocked to that hash, could represent wallet
-				"unlockhash": "01abc0123abc0123abc0123abc0123abc0abc0123abc0123abc0123abc0123abc057382370c8d9"
-			},
-			{
-				"value": "8", // currency value (in smallest unit), big integer as string, required, positive
-				// output's unlock hash, specifier output will belocked to that hash, could represent wallet
-				"unlockhash": "02abc0123abc0123abc0123abc0123abc0abc0123abc0123abc0123abc0123abc0ee7715ac0e0e"
-			}
-		],
-		"blockstakeinputs": [ // block stake inputs, optional
-			{
-				// blockstake output ID, crypto hash (blake2b, 256 bit), required, hex-encoded
-				"parentid": "dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfde",
-				// input lock, required
-				"unlocker": {
-					"type": 1, 	// input lock, byte, supported range: [1,2], unknown range: [3,255], required
-											// `1` = SingleSignature, `2` = AtomicSwap
-					"condition": { // unlock condition, required, format dependend upon sibling "type" property
-						// public key, required, format: `<algorithmSpecifier>:<key>`, where <key> is hex-encoded
-						// and which byte-size is fixed but dependend upon the <algorithmSpecifier>,
-						// <algorithmSpecifier> can currently only be `"ed25519"`
-						"publickey": "ed25519:ef1234ef1234ef1234ef1234ef1234ef1234ef1234ef1234ef1234ef1234ef12"
-					},
-					"fulfillment": { 	// unlock fulfillment, fulfills the unlock condition, required,
-														// format dependend upon sibling "type" property
-						// public key, required, format: `<algorithmSpecifier>:<key>`, where <key> is hex-encoded
-						// and which byte-size is fixed but dependend upon the <algorithmSpecifier>,
-						// <algorithmSpecifier> can currently only be `"ed25519"`
-						"signature": "01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def"
-					}
-				}
-			},
-			{
-				// blockstake output ID, crypto hash (blake2b, 256 bit), required, hex-encoded
-				"parentid": "fed42fed42fed42fed42fed42fed42fed42fed42fed42fed42fed42fed42fed4",
-				"unlocker": {
-					"type": 42, // input lock, byte, supported range: [1,2], unknown range: [3,255], required
-											// `1` = SingleSignature, `2` = AtomicSwap, other = unknown
-					// unlock condition, required,
-					// base64 encoding of the input lock condition in binary encoding format,
-					"condition": "Y29uZGl0aW9u",
-					// unlock fulfillment, required,
-					// base64 encoding of the input fulfillment condition in binary encoding format,
-					"fulfillment": "ZnVsZmlsbG1lbnQ="
-				}
-			}
-		],
-		"blockstakeoutputs": [ // block stake outputs, optional
-			{
-				"value": "4", // currency value (in smallest unit), big integer as string, required, positive
-				// output's unlock hash, specifier output will belocked to that hash, could represent wallet
-				"unlockhash": "2a0123456789012345678901234567890101234567890123456789012345678901baa780c3d6f2"
-			},
-			{
-				"value": "2", // currency value (in smallest unit), big integer as string, required, positive
-				// output's unlock hash, specifier output will belocked to that hash, could represent wallet
-				"unlockhash": "18abc0123abc0123abc0123abc0123abc0abc0123abc0123abc0123abc0123abc09c8b0a79cf2b"
-			}
-		],
-		// miner fees, list of currency values, at least 1 required
-		"minerfees": ["1", "2", "3"],
-		// arbitrary data, optional, base64 encoded
-		"arbitrarydata": "ZGF0YQ==" // represents "data" in base64 encoding
-	}
+    "version": byte, // byte identifying the (transaction) version
+    "data": data // format of data depends upon the (transaction) version
 }
 ```
 
-The details of the text (JSON) encoding of an unlock hash are described in
+A Transaction is given as part of a body, which is always JSON-encoded as follows:
+
+```javascript
+{
+    "parentid": blockID, // ID of the previous block, the nil-block if this block is the genesis block
+    "timestamp": uint64, // creation Unix Epoch timestamp of the block
+    "pobsindexes": { // indices and values required for the POBS protocol.
+        "BlockHeight": blockHeight,
+        "TransactionIndex": uint64,
+        "OutputIndex": uint64,
+    },
+    "minerpayouts": [
+        {
+            "value": currency,
+            "unlockhash": unlockHash, // see /doc/transactions/unlockhash.md to learn how this is encoded
+        },
+    ],
+    "transactions": [txn1, ...] // where each txn1 is encoded as discussed earlier
+}
+```
+
+### JSON Encoding of Types
+
+The encoding of primitives such as integers, booleans and strings behave just the same
+as in any other JSON encoding you might have seen before.
+
+A currency (coins/block stakes), represented in memory as a Big Integer, is JSON-encoded into a string, representing
+the number in the human-readable 10-base format you're used to. (e.g. `1234` is represented as `"1234"`).
+
+Arbitrary data, which in memory is a raw byte slice, is base64-encoded into a string when part of a JSON structure.
+
+Any kind of Identifier type (e.g. CoinOutputID][conid], [BlockStakeOutputID][bsoid], OutputID][outid], [TransactionID][txnid] and [BlockID][blkid]) is hex encoded into a string with a static length of 64 characters, when part of a JSON structure.
+
+Pointer types are only encoded when not nil, in which case their value type is used to encode (except when [the `json.Marshaler` interface](https://godoc.org/encoding/json#Marshaler) (in the Rivine Golang lib) is supported by that pointer type).
+
+Types are always encoded using custom logic if [the `json.Marshaler` interface]((https://godoc.org/encoding/json#Marshaler))
+is supported (in the Rivine Golang lib).
+
+Properties of structures are only encoded if they are marked as public
+(in golang a property is public if it starts with a capital letter).
+The exception is again if the structure type implements [the `json.Marshaler` interface](https://godoc.org/encoding/json#Marshaler).
+
+Arrays and slices are encoded as JSON arrays, where the elements are than encoded one by one depending upon their type.
+
+Anything that uses the `ByteSlice` Golang type, is also encoded as a hex-encoded string.
+Example of a `ByteSlice` are: signatures, secrets, keys and hashed secrets.
+
+When decoding JSON-encoded data, it is assumed that you know the structure, and it will use your provided value's type in order to know how to decode it. The exception to this rule again (when using the Rivine Go Library) is that if the given value's type implements [the `json.Unmarshaler` interface](https://godoc.org/encoding/json#Unmarshaler), it is decoded using the custom defined logic.
+
+When you know these rules (and exceptions) it should be trivial to deduce how any given type is JSON-encoded and decoded,
+given that you know how the type is defined and which interfaces it implements.
+
+### JSON encoding of v1 Transactions
+
+Before we show a full example of a v1 transaction in JSON-encoded form,
+with some possible input and output types,
+let's see how inputs and outputs are JSON-encoded, as the encoding of those are different
+in v1 transactions compared to v0 transactions.
+
+Understanding the following [inputs](#json-encoding-of-inputs-in-v1-transactions) and [outputs](#json-encoding-of-outputs-in-v1-transactions) chapters,
+together with [the JSON Encoding of Types chapter](#json-encoding-of-types),
+should make you able to understand the [Example of a JSON-encoded v1 Transaction](#example-of-a-json-encoded-v1-transaction),
+without a sweat.
+
+#### JSON Encoding of Inputs in v1 Transactions
+
+Block stake- and coin- inputs are optional, and both are encoded in the same format:
+
+```javascript
+{
+    // coin/blockstake output ID, crypto hash (blake2b, 256 bit), required, hex-encoded,
+    // linking the output that is planned to be spend by this input
+    "parentid": "dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfde",
+    "fulfillment": {
+        "type": byte,   // fulfillment type, byte, supported range: [1,2], required
+                        // `1` = SingleSignature, `2` = AtomicSwap
+        "data": data, // structure of the fulfillment depends upon the sibling type byte
+    },
+}
+```
+
+The `fulfillment`'s `type` defines the JSON-encoded format of the `fulfillment`'s `data` property.
+
+##### JSON Encoding of a SingleSignatureFulfillment
+
+When the `fulfillment`'s `type` equals `1`, it indicates a SingleSignature Fulfillment,
+with as consequence that the fulfillment will have the following JSON-encoded format:
+
+```javascript
+{
+    "type": 1, // indicates a SingleSignature Fulfillment
+    "data": {
+        // public key, required, format: `<algorithmSpecifier>:<key>`, where <key> is hex-encoded
+        // and which byte-size is fixed but dependend upon the <algorithmSpecifier>,
+        // <algorithmSpecifier> can currently only be `"ed25519"`
+        "publickey": "ed25519:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        // signature, byte-size is fixed but dependend upon the <algorithmSpecifier>,
+        // when <algorithmSpecifier> equals `"ed25519"` the byte size is 64, required, hex-encoded
+        "signature": "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefab"
+    }
+}
+```
+
+##### JSON Encoding of an AtomicSwapFulfillment
+
+When the `fulfillment`'s `type` equals `2`, it indicates an AtomicSwap Fulfillment,
+with as consequence that the fulfillment will usually have the following JSON-encoded format:
+
+```javascript
+{
+    "type": 2, // indicates an AtomicSwap Fulfillment (in the new/v1 format)
+    "data": {
+        // public key, required, format: `<algorithmSpecifier>:<key>`, where <key> is hex-encoded
+        // and which byte-size is fixed but dependent upon the <algorithmSpecifier>,
+        // <algorithmSpecifier> can currently only be `"ed25519"`
+        "publickey": "ed25519:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        // signature, byte-size is fixed but dependend upon the <algorithmSpecifier>,
+        // when <algorithmSpecifier> equals `"ed25519"` the byte size is 64, required, hex-encoded
+        "signature": "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefab",
+        // secret, fixed size, 32 bytes, hex-encoded
+        // optional, and doesn't have to be given if this is a refund rather than a claim
+        "secret": "def789def789def789def789def789dedef789def789def789def789def789de"
+    }
+}
+```
+
+It can however also have the following legacy/v0 JSON-encoded format:
+
+```javascript
+{
+    "type": 2, // indicates an AtomicSwap Fulfillment (in the new/v1 format)
+    "data": {
+        // sender's unlock hash, required, hex-encoded, fixed-size
+        "sender": "01654f96b317efe5fd6cd8ba1a394dce7b6ebe8c9621d6c44cbe3c8f1b58ce632a3216de71b23b",
+        // receiver's unlock hash, required, hex-encoded, fixed-size
+        "receiver": "01e89843e4b8231a01ba18b254d530110364432aafab8206bea72e5a20eaa55f70b1ccc65e2105",
+        // hashed secret, fixed size, 32 bytes, hex-encoded, sha256(secret)
+        "hashedsecret": "abc543defabc543defabc543defabc543defabc543defabc543defabc543defa",
+        // time lock, unix epoch timestamp (in seconds), 64-bit unsigned integer, required
+        "timelock": 1522068743,
+        // public key, required, format: `<algorithmSpecifier>:<key>`, where <key> is hex-encoded
+        // and which byte-size is fixed but dependent upon the <algorithmSpecifier>,
+        // <algorithmSpecifier> can currently only be `"ed25519"`
+        "publickey": "ed25519:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        // signature, byte-size is fixed but dependend upon the <algorithmSpecifier>,
+        // when <algorithmSpecifier> equals `"ed25519"` the byte size is 64, required, hex-encoded
+        "signature": "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefab",
+        // secret, fixed size, 32 bytes, hex-encoded
+        // optional, and doesn't have to be given if this is a refund rather than a claim
+        "secret": "def789def789def789def789def789dedef789def789def789def789def789de"
+}
+```
+
+Where the legacy/v0 format is meant to fulfill legacy UnlockHash-based conditions (ConditionType `1` with UnlockType `2`).
+While that format can also fulfill the new/v1 AtomicSwapCondition (ConditionType `2`),
+when fulfilling that condition it makes more sense to use the new/v1 format, as to avoid info-duplication.
+
+#### JSON Encoding of Outputs in v1 Transactions
+
+Block stake- and coin- outputs are optional, and both are encoded in the same format:
+
+```javascript
+{
+    // currency value (in smallest unit), big integer as string, required, positive
+    "value": "10000",
+    "condition": {
+        "type": byte,   // condition type, byte, supported range: [0,3], required
+                        // `0` = NilCondition, `1` = UnlockHashCondition,
+                        // `2` = AtomicSwapCondition, `3` = TimeLockCondition
+        "data": data, // structure of the fulfillment depends upon the sibling type byte
+    },
+}
+```
+
+The `condition`'s `type` defines the JSON-encoded format of the `condition`'s `data` property.
+
+##### JSON Encoding of a NilCondition
+
+The ConditionTypeNil (`0`) identifies a NilCondition,
+is the default condition type and always has the following format:
+
+```javascript
+{
+    "type": 0, // indicates a NilCondition
+    "data": {},
+}
+```
+
+As it is the default condition, you could however also just represent it
+as an empty JSON struct:
+
+```javascript
+{}
+```
+
+An output using a NilCondition can be spend anyone who owns a wallet address,
+simply by signing the input with a single signature, using a private key of choice.
+
+##### JSON Encoding of an UnlockHashCondition
+
+The ConditionTypeUnlockHash (`1`) identifies an UnlockHashCondition
+and is json-encoded in the following format:
+
+```javascript
+{
+    "type": 1, // indicates an UnlockHashCondition
+    "data": {
+        // output's unlock hash, specifier output will be locked to that hash
+        // the `0x01` prefix in this instance indicates that it is a PubKey Unlock Hash (a wallet address)
+        "unlockhash": "01a6a6c5584b2bfbd08738996cd7930831f958b9a5ed1595525236e861c1a0dc353bdcf54be7d8"
+    }
+}
+```
+
+The details of the JSON-encoding of an unlock hash are described in
+[/doc/transactions/unlockhash.md](/doc/transactions/unlockhash.md).
+
+Such condition can be fulfilled by proving the ownership of the private key,
+which is linked to the public key from which this unlock hash is derived.
+
+The signature, given as part of the fulfillment, is the proof.
+See [the Signing Transactions chapter](#signing-transactions) for more information.
+
+##### JSON Encoding of an AtomicSwapCondition
+
+The ConditionTypeAtomicSwap (`2`) identifies an AtomicSwapCondition
+and is json-encoded in the following format:
+
+```javascript
+{
+    "type": 2, // indicates an AtomicSwapCondition
+    "data": {
+        // sender's unlock hash, required, hex-encoded, fixed-size
+        "sender": "01654f96b317efe5fd6cd8ba1a394dce7b6ebe8c9621d6c44cbe3c8f1b58ce632a3216de71b23b",
+        // receiver's unlock hash, required, hex-encoded, fixed-size
+        "receiver": "01e89843e4b8231a01ba18b254d530110364432aafab8206bea72e5a20eaa55f70b1ccc65e2105",
+        // hashed secret, fixed size, 32 bytes, hex-encoded, sha256(secret)
+        "hashedsecret": "abc543defabc543defabc543defabc543defabc543defabc543defabc543defa",
+        // time lock, unix epoch timestamp (in seconds), 64-bit unsigned integer, required
+        "timelock": 1522068743
+    }
+}
+```
+
+How such condition can be fulfilled depends upon the height or timestamp of the last block in the chain.
+If the contract is active, the condition can be fulfilled by proving the ownership of the private key,
+which is linked to the public key from which the receiver unlock hash is derived. Otherwise the condition
+can be fulfilled by proving the ownership of the private key, which is linked to the public key from which
+the sender unlock hash is derived.
+
+The signature, given as part of the fulfillment, is the proof.
+See [the Signing Transactions chapter](#signing-transactions) for more information.
+
+##### JSON Encoding of a TimeLockCondition
+
+The ConditionTypeTimeLock (`3`) identifies a TimeLockCondition
+and is json-encoded in the following format:
+
+```javascript
+{
+    "type": 3, // indicates a TimeLockCondition
+    "data": {
+        // locktime identifies the height or timestamp until which this output is locked,
+        // meaning that as long as the last block's height/timestamp is less than this value,
+        // the output cannot be spend.
+        //
+        // If the locktime is less then 500 milion it is to be assumed to be identifying a block height,
+        // otherwise it identifies a unix epoch timestamp in seconds;
+        "locktime": 500000000,
+        // internal condition this TimeLockCondition wraps around,
+        // meaning that in order to fulfill this TimeLockCondition,
+        // this internal condition will have to be explicitly fulfilled on top
+        // of the implicit locktime fulfillment.
+        "condition": {
+            // Only support type is `1` (`UnlockHashCondition`)
+            "type": 1,
+            "data": {
+                // output's unlock hash, specifier output will be locked to that hash
+                // the `0x01` prefix in this instance indicates that it is a PubKey Unlock Hash (a wallet address),
+                // and that UnlockHash Type is also the only one supported by the TimeLockCondition.
+                "unlockhash": "0101234567890123456789012345678901012345678901234567890123456789018a50e31447b8"
+            }
+        }
+    }
+}
+```
+
+Such condition is to be fulfilled in 2 parts:
+
++ The first part is done implicitly, by ensuring the last block height or time is less than the height/time specified as LockTime.
++ If the first part has been fulfilled, the internal condition has to be fulfilled explicitly, by giving a fulfillment which is able to fulfill the internal condition, which is part of the TimeLockCondition and encoded as the very last thing;
+
+The constant which defines whether a LockTime is a Block Height or a Unix Epoch Timestamp in seconds,
+is `LockTimeMinTimestampValue` and is documented in <https://godoc.org/github.com/rivine/rivine/types#pkg-constants>.
+
+#### Example of a JSON-encoded v1 Transaction
+
+The JSON encoding of a v1 Transaction can be explained best using an example:
+
+```javascript
+{
+    "version": 1, // version ID, byte, always `1` for v1 transaction, required as this value is `0` by default
+    "data": { // actual transaction data, required
+        "coininputs": [ // coin inputs, optional
+            {
+                // coin output ID, crypto hash (blake2b, 256 bit), required, hex-encoded
+                "parentid": "abcdef012345abcdef012345abcdef012345abcdef012345abcdef012345abcd",
+                // fulfillment, used to fulfill the condition of the output identified by the above parentID
+                "fulfillment": {
+                    // fulfillment type, byte, supported range: [1,2], required
+                    // `1` = SingleSignature, `2` = AtomicSwap
+                    "type": 1,
+                    "data": {   // actual fulfillment data, requirement depends upon sibling type property,
+                                // in this instance it represents a SingleSignature Fulfillment
+                        // public key, required, format: `<algorithmSpecifier>:<key>`, where <key> is hex-encoded
+                        // and which byte-size is fixed but dependend upon the <algorithmSpecifier>,
+                        // <algorithmSpecifier> can currently only be `"ed25519"`
+                        "publickey": "ed25519:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                        // signature, byte-size is fixed but dependend upon the <algorithmSpecifier>,
+                        // when <algorithmSpecifier> equals `"ed25519"` the byte size is 64, required, hex-encoded
+                        "signature": "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefab"
+                    }
+                }
+            },
+            {
+                // coin output ID, crypto hash (blake2b, 256 bit), required, hex-encoded
+                "parentid": "012345defabc012345defabc012345defabc012345defabc012345defabc0123",
+                // fulfillment, used to fulfill the condition of the output identified by the above parentID
+                "fulfillment": {
+                    // fulfillment type, byte, supported range: [1,2], required
+                    // `1` = SingleSignature, `2` = AtomicSwap
+                    "type": 2,
+                    "data": {   // actual fulfillment data, requirement depends upon sibling type property,
+                                // in this instance it represents an AtomicSwap Fulfillment in the new/v1 format
+                        // public key, required, format: `<algorithmSpecifier>:<key>`, where <key> is hex-encoded
+                        // and which byte-size is fixed but dependend upon the <algorithmSpecifier>,
+                        // <algorithmSpecifier> can currently only be `"ed25519"`
+                        "publickey": "ed25519:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                        // signature, byte-size is fixed but dependend upon the <algorithmSpecifier>,
+                        // when <algorithmSpecifier> equals `"ed25519"` the byte size is 64, required, hex-encoded
+                        "signature": "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefab",
+                        // secret, fixed size, 32 bytes, hex-encoded
+                        "secret": "def789def789def789def789def789dedef789def789def789def789def789de"
+                    }
+                }
+            },
+            {
+                // coin output ID, crypto hash (blake2b, 256 bit), required, hex-encoded
+                "parentid": "045645defabc012345defabc012345defabc012345defabc012345defabc0123",
+                // fulfillment, used to fulfill the condition of the output identified by the above parentID
+                "fulfillment": {
+                    // fulfillment type, byte, supported range: [1,2], required
+                    // `1` = SingleSignature, `2` = AtomicSwap
+                    "type": 2,
+                    "data": {   // actual fulfillment data, requirement depends upon sibling type property,
+                                // in this instance it represents an AtomicSwap Fulfillment in the legacy/v0 format
+                        // sender's unlock hash, required, hex-encoded, fixed-size
+                        "sender": "01654f96b317efe5fd6cd8ba1a394dce7b6ebe8c9621d6c44cbe3c8f1b58ce632a3216de71b23b",
+                        // receiver's unlock hash, required, hex-encoded, fixed-size
+                        "receiver": "01e89843e4b8231a01ba18b254d530110364432aafab8206bea72e5a20eaa55f70b1ccc65e2105",
+                        // hashed secret, fixed size, 32 bytes, hex-encoded, sha256(secret)
+                        "hashedsecret": "abc543defabc543defabc543defabc543defabc543defabc543defabc543defa",
+                        // time lock, unix epoch timestamp (in seconds), 64-bit unsigned integer, required
+                        "timelock": 1522068743,
+                        // public key, required, format: `<algorithmSpecifier>:<key>`, where <key> is hex-encoded
+                        // and which byte-size is fixed but dependend upon the <algorithmSpecifier>,
+                        // <algorithmSpecifier> can currently only be `"ed25519"`
+                        "publickey": "ed25519:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                        // signature, byte-size is fixed but dependend upon the <algorithmSpecifier>,
+                        // when <algorithmSpecifier> equals `"ed25519"` the byte size is 64, required, hex-encoded
+                        "signature": "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefab",
+                        // secret, fixed size, 32 bytes, hex-encoded
+                        "secret": "def789def789def789def789def789dedef789def789def789def789def789de"
+                    }
+                }
+            }
+        ],
+        "coinoutputs": [ // coin outputs, optional
+            {
+                "value": "3", // currency value (in smallest unit), big integer as string, required, positive
+                // condition, used to define what condition has to be fulfilled in order to spend this output
+                "condition": {
+                    // condition type, byte, supported range: [0,3], required
+                    // `0` = NilCondition, `1` = UnlockHashCondition, `2` = AtomicSwapCondition
+                    // `3` = TimeLockCondition
+                    "type": 1,
+                    "data": {    // actual condition data, requirement depends upon sibling type property,
+                                // in this instance it represents an UnlockHashCondition
+                        // output's unlock hash, specifier output will be locked to that hash
+                        // the `0x01` prefix in this instance indicates that it is a PubKey Unlock Hash (a wallet address)
+                        "unlockhash": "0142e9458e348598111b0bc19bda18e45835605db9f4620616d752220ae8605ce0df815fd7570e"
+                    }
+                }
+            },
+            {
+                "value": "5", // currency value (in smallest unit), big integer as string, required, positive
+                // condition, used to define what condition has to be fulfilled in order to spend this output
+                "condition": {
+                    // condition type, byte, supported range: [0,3], required
+                    // `0` = NilCondition, `1` = UnlockHashCondition, `2` = AtomicSwapCondition
+                    // `3` = TimeLockCondition
+                    "type": 1,
+                    "data": {   // actual condition data, requirement depends upon sibling type property,
+                                // in this instance it represents an UnlockHashCondition
+                        // output's unlock hash, specifier output will be locked to that hash
+                        // the `0x01` prefix in this instance indicates that it is a PubKey Unlock Hash (a wallet address)
+                        "unlockhash": "01a6a6c5584b2bfbd08738996cd7930831f958b9a5ed1595525236e861c1a0dc353bdcf54be7d8"
+                    }
+                }
+            },
+            {
+                "value": "8", // currency value (in smallest unit), big integer as string, required, positive
+                // condition, used to define what condition has to be fulfilled in order to spend this output
+                "condition": {
+                    // condition type, byte, supported range: [0,3], required
+                    // `0` = NilCondition, `1` = UnlockHashCondition, `2` = AtomicSwapCondition
+                    // `3` = TimeLockCondition
+                    "type": 1,
+                    "data": {   // actual condition data, requirement depends upon sibling type property,
+                                // in this instance it represents an UnlockHashCondition
+                        "unlockhash": "02a24c97c80eeac111aa4bcbb0ac8ffc364fa9b22da10d3054778d2332f68b365e5e5af8e71541"
+                    }
+                }
+            },
+            {
+                "value": "13", // currency value (in smallest unit), big integer as string, required, positive
+                // condition, used to define what condition has to be fulfilled in order to spend this output
+                "condition": {
+                    // condition type, byte, supported range: [0,3], required
+                    // `0` = NilCondition, `1` = UnlockHashCondition, `2` = AtomicSwapCondition
+                    // `3` = TimeLockCondition
+                    "type": 2,
+                    "data": {   // actual condition data, requirement depends upon sibling type property,
+                                // in this instance it represents an AtomicSwapCondition
+                        // sender's unlock hash, required, hex-encoded, fixed-size
+                        "sender": "01654f96b317efe5fd6cd8ba1a394dce7b6ebe8c9621d6c44cbe3c8f1b58ce632a3216de71b23b",
+                        // receiver's unlock hash, required, hex-encoded, fixed-size
+                        "receiver": "01e89843e4b8231a01ba18b254d530110364432aafab8206bea72e5a20eaa55f70b1ccc65e2105",
+                        // hashed secret, fixed size, 32 bytes, hex-encoded, sha256(secret)
+                        "hashedsecret": "abc543defabc543defabc543defabc543defabc543defabc543defabc543defa",
+                        // time lock, unix epoch timestamp (in seconds), 64-bit unsigned integer, required
+                        "timelock": 1522068743
+                    }
+                }
+            }
+        ],
+        "blockstakeinputs": [ // block stake inputs, optional
+            {
+                // block stake output ID, crypto hash (blake2b, 256 bit), required, hex-encoded
+                "parentid": "dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfde",
+                // fulfillment, used to fulfill the condition of the output identified by the above parentID
+                "fulfillment": {
+                    // fulfillment type, byte, supported range: [1,2], required
+                    // `1` = SingleSignature, `2` = AtomicSwap
+                    "type": 1,
+                    "data": {   // actual fulfillment data, requirement depends upon sibling type property,
+                                // in this instance it represents a SingleSignature Fulfillment
+                        // public key, required, format: `<algorithmSpecifier>:<key>`, where <key> is hex-encoded
+                        // and which byte-size is fixed but dependend upon the <algorithmSpecifier>,
+                        // <algorithmSpecifier> can currently only be `"ed25519"`
+                        "publickey": "ed25519:ef1234ef1234ef1234ef1234ef1234ef1234ef1234ef1234ef1234ef1234ef12",
+                        // signature, byte-size is fixed but dependend upon the <algorithmSpecifier>,
+                        // when <algorithmSpecifier> equals `"ed25519"` the byte size is 64, required, hex-encoded
+                        "signature": "01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def"
+                    }
+                }
+            }
+        ],
+        "blockstakeoutputs": [ // block stake outputs, optional
+            {
+                "value": "4", // currency value (in smallest unit), big integer as string, required, positive
+                // condition, used to define what condition has to be fulfilled in order to spend this output
+                "condition": {
+                    // condition type, byte, supported range: [0,3], required
+                    // `0` = NilCondition, `1` = UnlockHashCondition, `2` = AtomicSwapCondition
+                    // `3` = TimeLockCondition
+                    "type": 1,
+                    "data": {   // actual condition data, requirement depends upon sibling type property,
+                                // in this instance it represents an UnlockHashCondition
+                        // output's unlock hash, specifier output will be locked to that hash
+                        // the `0x01` prefix in this instance indicates that it is a PubKey Unlock Hash (a wallet address)
+                        "unlockhash": "01a6a6c5584b2bfbd08738996cd7930831f958b9a5ed1595525236e861c1a0dc353bdcf54be7d8"
+                    }
+                }
+            }
+        ],
+        // miner fees, list of currency values, at least 1 required
+        "minerfees": ["1", "2", "3"],
+        // arbitrary data, optional, base64 encoded
+        "arbitrarydata": "ZGF0YQ=="
+    }
+}
+```
+
+### JSON encoding of v0 Transactions
+
+Before we show a full example of a v0 transaction in JSON-encoded form,
+with some possible input and output types,
+let's see how inputs and outputs are JSON-encoded, as the encoding of those are different
+in v0 transactions compared to v1 transactions.
+
+Understanding the following [inputs](#json-encoding-of-inputs-in-v0-transactions) and [outputs](#json-encoding-of-outputs-in-v0-transactions) chapters,
+together with [the JSON Encoding of Types chapter](#json-encoding-of-types),
+should make you able to understand the [Example of a JSON-encoded v0 Transaction](#example-of-a-json-encoded-v0-transaction),
+without a sweat.
+
+#### JSON encoding of Inputs in v0 Transactions
+
+Block stake- and coin- inputs are optional, and both are encoded in the same format:
+
+```javascript
+{
+    // coin/blockstake output ID, crypto hash (blake2b, 256 bit), required, hex-encoded,
+    // linking the output that is planned to be spend by this input
+    "parentid": "dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfde",
+    "unlocker": {
+        "type": byte,    // input lock, byte, supported range: [1,2], required
+                        // `1` = SingleSignature, `2` = AtomicSwap
+        "condition": condition, // structure of the condition depends upon the sibling type byte
+        "fulfillment": fulfillment, // structure of the fulfillment depends upon the sibling type byte
+    },
+}
+```
+
+The `unlocker`'s `type` defines the JSON-encoded format of the `condition` and `fulfillment`.
+
+##### JSON Encoding of a SingleSignature InputLock
+
+When the `unlocker`'s `type` equals `1`, it indicates a SingleSignature InputLock,
+with as consequence that the unlocker will have the following JSON-encoded format:
+
+```javascript
+{
+    "type": 1, // indicates a SingleSignature Input Lock
+    "condition": {
+        // public key, required, format: `<algorithmSpecifier>:<key>`, where <key> is hex-encoded
+        // and which byte-size is fixed but dependend upon the <algorithmSpecifier>,
+        // <algorithmSpecifier> can currently only be `"ed25519"`
+        "publickey": "ed25519:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    },
+    "fulfillment": {
+        // signature, byte-size is fixed but dependend upon the <algorithmSpecifier>,
+        // when <algorithmSpecifier> equals `"ed25519"` the byte size is 64, required, hex-encoded
+        "signature": "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefab"
+    }
+}
+```
+
+##### JSON Encoding of an AtomicSwap InputLock
+
+When the `unlocker`'s `type` equals `2`, it indicates an AtomicSwap InputLock,
+with as consequence that the unlocker will have the following JSON-encoded format:
+
+```javascript
+{
+    "type": 2, // indicates an AtomicSwap Input Lock
+    "condition": {
+        // sender's unlock hash, required, hex-encoded, fixed-size
+        "sender": "0101234567890123456789012345678901012345678901234567890123456789018a50e31447b8",
+        // receiver's unlock hash, required, hex-encoded, fixed-size
+        "receiver": "01abc0123abc0123abc0123abc0123abc0abc0123abc0123abc0123abc0123abc057382370c8d9",
+        // hashed secret, fixed size, 32 bytes, hex-encoded, sha256(secret)
+        "hashedsecret": "abc543defabc543defabc543defabc543defabc543defabc543defabc543defa",
+        // time lock, unix epoch timestamp (in seconds), 64-bit unsigned integer, required
+        "timelock": 1522068743
+    },
+    "fulfillment": {
+        // public key, required, format: `<algorithmSpecifier>:<key>`, where <key> is hex-encoded
+        // and which byte-size is fixed but dependend upon the <algorithmSpecifier>,
+        // <algorithmSpecifier> can currently only be `"ed25519"`
+        "publickey": "ed25519:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        // signature, byte-size is fixed but dependend upon the <algorithmSpecifier>,
+        // when <algorithmSpecifier> equals `"ed25519"` the byte size is 64, required, hex-encoded
+        "signature": "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefab",
+        // secret, fixed size, 32 bytes, hex-encoded,
+        // optional, and doesn't have to be given if this is a refund rather than a claim
+        "secret": "def789def789def789def789def789dedef789def789def789def789def789de"
+    }
+}
+```
+
+#### JSON Encoding of Outputs in v0 Transactions
+
+The JSON-encoded format of coin- and blockstake- outputs are always the same in v0 transactions:
+
+```javascript
+{
+    // currency value (in smallest unit), big integer as string, required, positive
+    "value": "10000",
+
+    // output's unlock hash, specifier output will be locked to that hash, could represent wallet,
+    // unlock type identified by the first hex-decoded byte in the unlock hash,
+    // which is `0x01` in this example, telling us that this is
+    // a PubKeyUnlockHash (and thus indeed a wallet address).
+    //
+    // See /doc/transactions/unlockhash.md to learn more about unlock hashes
+    // and the JSON-encoding of the different types of unlock hashes
+    "unlockhash": "01abc0123abc0123abc0123abc0123abc0abc0123abc0123abc0123abc0123abc057382370c8d9",
+}
+```
+
+#### Example of a JSON-encoded v0 Transaction
+
+The JSON encoding of a v0 Transaction can be explained best using an example:
+
+```javascript
+{
+    "version": 0, // version ID, byte, always `0` for v0 transaction, optional
+    "data": { // actual transaction data, required
+        "coininputs": [ // coin inputs, optional
+            {
+                // coin output ID, crypto hash (blake2b, 256 bit), required, hex-encoded
+                "parentid": "abcdef012345abcdef012345abcdef012345abcdef012345abcdef012345abcd",
+                // input lock, required
+                "unlocker": {
+                    "type": 1,  // input lock, byte, supported range: [1,2], required
+                                // `1` = SingleSignature, `2` = AtomicSwap
+                    "condition": { // unlock condition, required, format dependend upon sibling "type" property
+                        // public key, required, format: `<algorithmSpecifier>:<key>`, where <key> is hex-encoded
+                        // and which byte-size is fixed but dependend upon the <algorithmSpecifier>,
+                        // <algorithmSpecifier> can currently only be `"ed25519"`
+                        "publickey": "ed25519:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                    },
+                    "fulfillment": {    // unlock fulfillment, fulfills the unlock condition, required,
+                                        // format dependend upon sibling "type" property
+                        // signature, byte-size is fixed but dependend upon the <algorithmSpecifier>,
+                        // when <algorithmSpecifier> equals `"ed25519"` the byte size is 64, required, hex-encoded
+                        "signature": "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefab"
+                    }
+                }
+            },
+            {
+                // coin output ID, crypto hash (blake2b, 256 bit), required, hex-encoded
+                "parentid": "012345defabc012345defabc012345defabc012345defabc012345defabc0123",
+                // input lock, required
+                "unlocker": {
+                    "type": 2,  // input lock, byte, supported range: [1,2], required
+                                // `1` = SingleSignature, `2` = AtomicSwap
+                    "condition": { // unlock condition, required, format dependend upon sibling "type" property
+                        // sender's unlock hash, required, hex-encoded, fixed-size
+                        "sender": "0101234567890123456789012345678901012345678901234567890123456789018a50e31447b8",
+                        // receiver's unlock hash, required, hex-encoded, fixed-size
+                        "receiver": "01abc0123abc0123abc0123abc0123abc0abc0123abc0123abc0123abc0123abc057382370c8d9",
+                        // hashed secret, fixed size, 32 bytes, hex-encoded, sha256(secret)
+                        "hashedsecret": "abc543defabc543defabc543defabc543defabc543defabc543defabc543defa",
+                        // time lock, unix epoch timestamp (in seconds), 64-bit unsigned integer, required
+                        "timelock": 1522068743
+                    },
+                    "fulfillment": {    // unlock fulfillment, fulfills the unlock condition, required,
+                                        // format dependend upon sibling "type" property
+                        // public key, required, format: `<algorithmSpecifier>:<key>`, where <key> is hex-encoded
+                        // and which byte-size is fixed but dependend upon the <algorithmSpecifier>,
+                        // <algorithmSpecifier> can currently only be `"ed25519"`
+                        "publickey": "ed25519:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                        // signature, byte-size is fixed but dependend upon the <algorithmSpecifier>,
+                        // when <algorithmSpecifier> equals `"ed25519"` the byte size is 64, required, hex-encoded
+                        "signature": "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefab",
+                        // secret, fixed size, 32 bytes, hex-encoded
+                        "secret": "def789def789def789def789def789dedef789def789def789def789def789de"
+                    }
+                }
+            }
+        ],
+        "coinoutputs": [ // coin outputs, optional
+            {
+                "value": "3", // currency value (in smallest unit), big integer as string, required, positive
+                // output's unlock hash, specifier output will be locked to that hash, could represent wallet
+                "unlockhash": "0101234567890123456789012345678901012345678901234567890123456789018a50e31447b8"
+            },
+            {
+                "value": "5", // currency value (in smallest unit), big integer as string, required, positive
+                // output's unlock hash, specifier output will be locked to that hash, could represent wallet
+                "unlockhash": "01abc0123abc0123abc0123abc0123abc0abc0123abc0123abc0123abc0123abc057382370c8d9"
+            },
+            {
+                "value": "8", // currency value (in smallest unit), big integer as string, required, positive
+                // output's unlock hash, specifier output will be locked to that hash, could represent wallet
+                "unlockhash": "02abc0123abc0123abc0123abc0123abc0abc0123abc0123abc0123abc0123abc0ee7715ac0e0e"
+            }
+        ],
+        "blockstakeinputs": [ // block stake inputs, optional
+            {
+                // blockstake output ID, crypto hash (blake2b, 256 bit), required, hex-encoded
+                "parentid": "dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfde",
+                // input lock, required
+                "unlocker": {
+                    "type": 1,  // input lock, byte, supported range: [1,2], required
+                                // `1` = SingleSignature, `2` = AtomicSwap
+                    "condition": { // unlock condition, required, format dependend upon sibling "type" property
+                        // public key, required, format: `<algorithmSpecifier>:<key>`, where <key> is hex-encoded
+                        // and which byte-size is fixed but dependend upon the <algorithmSpecifier>,
+                        // <algorithmSpecifier> can currently only be `"ed25519"`
+                        "publickey": "ed25519:ef1234ef1234ef1234ef1234ef1234ef1234ef1234ef1234ef1234ef1234ef12"
+                    },
+                    "fulfillment": {    // unlock fulfillment, fulfills the unlock condition, required,
+                                        // format dependend upon sibling "type" property
+                        // public key, required, format: `<algorithmSpecifier>:<key>`, where <key> is hex-encoded
+                        // and which byte-size is fixed but dependend upon the <algorithmSpecifier>,
+                        // <algorithmSpecifier> can currently only be `"ed25519"`
+                        "signature": "01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def"
+                    }
+                }
+            },
+            {
+                // blockstake output ID, crypto hash (blake2b, 256 bit), required, hex-encoded
+                "parentid": "fed42fed42fed42fed42fed42fed42fed42fed42fed42fed42fed42fed42fed4",
+                "unlocker": {
+                    "type": 42, // input lock, byte, supported range: [1,2], required
+                                // `1` = SingleSignature, `2` = AtomicSwap, other = unknown
+                    // unlock condition, required,
+                    // base64 encoding of the input lock condition in binary encoding format,
+                    "condition": "Y29uZGl0aW9u",
+                    // unlock fulfillment, required,
+                    // base64 encoding of the input fulfillment condition in binary encoding format,
+                    "fulfillment": "ZnVsZmlsbG1lbnQ="
+                }
+            }
+        ],
+        "blockstakeoutputs": [ // block stake outputs, optional
+            {
+                "value": "4", // currency value (in smallest unit), big integer as string, required, positive
+                // output's unlock hash, specifier output will be locked to that hash, could represent wallet
+                "unlockhash": "2a0123456789012345678901234567890101234567890123456789012345678901baa780c3d6f2"
+            },
+            {
+                "value": "2", // currency value (in smallest unit), big integer as string, required, positive
+                // output's unlock hash, specifier output will be locked to that hash, could represent wallet
+                "unlockhash": "18abc0123abc0123abc0123abc0123abc0abc0123abc0123abc0123abc0123abc09c8b0a79cf2b"
+            }
+        ],
+        // miner fees, list of currency values, at least 1 required
+        "minerfees": ["1", "2", "3"],
+        // arbitrary data, optional, base64 encoded
+        "arbitrarydata": "ZGF0YQ==" // represents "data" in base64 encoding
+    }
+}
+```
+
+The details of the JSON-encoding of an unlock hash are described in
 [/doc/transactions/unlockhash.md](/doc/transactions/unlockhash.md).
 
 You can learn more about atomic swaps in
 [/doc/atomicswap/atomicswap.md](/doc/atomicswap/atomicswap.md).
 
-Please read [the output identifiers section](#output-identifiers) to
-learn more about how coin- and block stake output identifiers are generated.
+## Binary Encoding
 
-Notes for soft-forks:
+### Introduction to Binary encoding
 
-+ When `"version"` defines an unknown version (anything other than `0` at the moment), the data should simply define the transaction as a base64 encoding of the binary encoding format of a transaction;
-+ When an input's `"type"` defines an unknown unlock type (anything more than `2` at the moment), the condition and fulfillment should be the base64 encoding of the binary encoded format of those conditions and fulfillments;
+Binary encoding is used for the following purposes:
 
-Another, this time very minimalistic, example:
++ persistent storage of blockchain data by the daemon's modules (e.g. consensus): see the `/modules` package and all its subpackages to see this in its full detail;
++ blockchain data and any other data exchanged between peers, using the `gateway` module: see [/doc/RPC.md](/doc/RPC.md) for more information;
++ signature creation: see [the Signing Transactions chapter](#signing-transactions) for more information;
 
-```javascript
-{
-	"version": 0, // version ID, byte, for now always `0`, optional
-	"data": { // actual transaction, required
-		"coininputs": [ // coin inputs, at least 1 element required
-			{
-				// coin output ID, crypto hash (blake2b, 256 bit), required, hex-encoded
-				"parentid": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-				// input lock, required
-				"unlocker": {
-					"type": 1, 	// input lock, byte, supported range: [1,2], unknown range: [3,255], required
-											// `1` = SingleSignature, `2` = AtomicSwap, other = unknown
-					"condition": { // unlock condition, required, format dependend upon sibling "type" property
-						// public key, required, format: `<algorithmSpecifier>:<key>`, where <key> is hex-encoded
-						// and which byte-size is fixed but dependend upon the <algorithmSpecifier>,
-						// <algorithmSpecifier> can currently only be `"ed25519"`
-						"publickey": "ed25519:def123def123def123def123def123def123def123def123def123def123def1"
-					},
-					"fulfillment": { 	// unlock fulfillment, fulfills the unlock condition, required,
-														// format dependend upon sibling "type" property
-						// signature, byte-size is fixed but dependend upon the <algorithmSpecifier>,
-						// when <algorithmSpecifier> equals `"ed25519"` the byte size is 64, required, hex-encoded
-						"signature": "ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef"
-					}
-				}
-			}
-		],
-		// miner fees, list of currency values, at least 1 required
-		"minerfees": ["1"],
-		// arbitrary data, optional, base64 encoded
-		"arbitrarydata": "SGVsbG8sIFdvcmxkIQ=="  // represents "Hello, World!" in base64 encoding
-	}
-}`
-```
+The first byte of every binary-encoded transaction always indicates the version of the transaction.
+For example the `0` byte indicates the legacy v0 transaction, while the `1` byte indicates the v1 transactons
+(which deprecate those v0 transactions).
 
-### Binary Format
+Blocks have no version, instead a block always has a fixed format, no matter the transaction version(s) used within that block.
 
-While the exact details of a transaction (binary encoding) depend upon which parts are used,
-and what types of inputs and outputs are used, all transactions do follow the same structure.
+### Binary Encoding of Types
 
-All parts of a transaction, and the serialized transaction as combined serialialized parts,
-are encoded using a binary little-endian based encoding algorithm.
-While some of it is repeated here as part of the detailed format explanation,
-it would still be helpful to read the detailed information that describes how this encoding algorithm
-works at [/doc/Encoding.md](/doc/Encoding.md).
+The encoding of Primitive types is explained in full in [/doc/Encoding.md](/doc/Encoding.md).
+With Primitive Types we mean integers, booleans, strings, arrays, slices and structures.
+In order to save you some time, it can however be summarized as:
 
-All transactions are always serialized in following order:
++ Booleans are encoded as either the `1` or `0` byte;
++ All integers are encoded using [Little Endian Order][litend] (that includes lengths);
++ All signed integers are encoded as 64-bit signed integers;
++ All unsigned integers are encoded as 64-bit unsigned integers;
++ Nil pointers are encoded as the `0` byte, while non-nil pointers are prefixed with the `1` byte, and encoded using its value type;
++ Arrays are simply encoded element by element, if it's a byte array that means simply all bytes are written as is;
++ Slices (dynamic arrays) are encoded the same way as Arrays, except that they're prefixed with a 64-bit signed integer indicating the length of the slice;
++ Structures are encoded by encoding the public properties one by one, in the order as defined;
 
-```
+The only exception to these rules (when using the Rivine Go Library) is if a type implements [the `SiaMarshaler` interface](https://godoc.org/github.com/rivine/rivine/encoding#SiaMarshaler), it is encoded using the custom defined logic.
+
+When decoding binary encoded data, it is assumed that you know the structure, and it will use your provided value's type in order to know how to decode it. The exception to this rule again (when using the Rivine Go Library) is that if the given value's type implements [the `SiaUnmarshaler` interface](https://godoc.org/github.com/rivine/rivine/encoding#SiaUnmarshaler), it is decoded using the custom defined logic.
+
+When you know these rules (and exceptions) it should be trivial to deduce how any given type is encoded,
+given that you know how the type is defined and which interfaces it implements.
+
+A standard transaction (`v0` and `v1` transactions) as we know it has the following structure:
+
+```plain
 +---------+------+------+------------+------------+-----------+-----------+
 | version | coin | coin | blockstake | blockstake | minerfees | arbitrary |
 |         | in   | out  | inputs     | outputs    |           | data      |
 +---------+------+------+------------+------------+-----------+-----------+
 ```
 
-Where version is always a single byte with as value `0x00` (until we support a new format), and where
-coin outputs, blockstake inputs, blockstake outputs and arbitrary data are all optional.
-
-As coin outputs, blockstake inputs and blockstake outputs are encoded as slices of data,
-they'll be encoded as a nil slice `0x0000000000000000` when not given, and thus still take 8 bytes each.
-
-Version, coin inputs and minerfees are required and will therefore always (have to) be defined.
-
-#### outputs
-
-The format of coin outputs and blockstake outputs are the same:
-
-```
-+----------+----------+-----+----------+
-| length N | output#1 | ... | output#N |
-+----------+----------+-----+----------+
-| 8 bytes  | where each output is      |
-|          | 87 bytes or more          |
-```
-
-Where each output is encoded as:
-
-```
-+--------------------------------------+-------------+
-| currency (big integer)               | unlock hash |
-+--------------------------------------+-------------+
-| length N     | big integer (N bytes) | (33 bytes)  |
-| (8 bytes)    |   absolute value &    |             |
-|              |   big endian          |             |
-```
-
-As you can see a currency is at least 9 bytes,
-due to the fact that we do not accept zero-value currencies.
-The length is always encoded as a 64-bit unsigned integer.
-
-An example of an encoded currency is `0x000000000000000101`, which stands for `1`.
-
-The details of the binary encoding of an unlock hash are described in
-[/doc/transactions/unlockhash.md](/doc/transactions/unlockhash.md).
-
-#### Miner Fees
+We've already seen in the introduction that (transaction) versions are encoded as a single byte.
 
 Miner fees are encoded as a slice of currencies:
 
-```
+```plain
 +----------+-------------+-----+-------------+
 | length N | currency #0 | ... | currency #N |
 +----------+-------------+-----+-------------+
@@ -346,41 +928,346 @@ Miner fees are encoded as a slice of currencies:
 |          | is 9 bytes or more              |
 ```
 
-Details of encoding of slices and currencies have been
-explained earlier in this document.
+A currency (coins or block stakes) are encoded as:
 
-#### Arbitrary Data
-
-As arbitrary data is an optional slice of bytes and encoded as follows:
-
-```
-+----------+-----------------+
-| length N | data byte slice |
-+----------+-----------------+
-| 8 bytes  | 0 or more bytes |
+```plain
++----------+-----------------------------------------------+
+| length N | absolute value encoded using Big Endian order |
++----------+-----------------------------------------------+
+| 8 bytes  | N bytes                                       |
 ```
 
-Therefore it follows that if no arbitrary data is attached to the transaction,
-it will be encoded as the nil slice `0x0000000000000000`. Should one want to attach `"42"`
-as arbitrary data to a transaction, it will be encoded as `0x00000000000000023432`.
+Arbitrary data is an optional slice of bytes and encoded as follows:
 
-#### inputs
-
-Blockstake inputs are optional, but coin inputs are required. The latter is explained
-due to the fact that minerfees are paid with coin inputs. Both are encoded in the same format however:
-
+```plain
++----------+---------------------+
+| length N |   data byte slice   |
++----------+---------------------+
+| 8 bytes  | N bytes (0 or more) |
 ```
+
+Therefore it follows that if no arbitrary data is given,
+it would be encoded as `0x0000000000000000`.
+
+Coin- and blockstake- inputs have a different structure depending upon
+if they are defined as part of a v0- or v1- transaction.
+In both versions however it contains a ParentID.
+
+A parentID has either the [CoinOutputID][conid] or [BlockStakeOutputID][bsoid] type,
+depending on whether is a coin- or a blockstake- input.
+These 2 types are just some of many identifier types in the Rivine protocol.
+Other examples of identifier types are [OutputID][outid], [TransactionID][txnid] and [BlockID][blkid].
+All of these identifiers types are simply alias of the `crypto.Hash` type,
+which is a 32-byte cryptographic hash, generated using the [blake2b 256-bit algorithm][blake2b].
+
+As all these identifier types are defined as a static 32-byte array,
+its encoding is simply the bytes written as-is:
+
+```plain
++-----------+
+| id (hash) |
++-----------+
+| 32 bytes  |
+```
+
+The binary encoding of public keys and unlock hashes and so on is explained in
+[/doc/transactions/unlockhash.md](/doc/transactions/unlockhash.md).
+
+Coin- and blockstake- outputs have a different structure depending upon
+if they are defined as part of a v0- or v1- transaction.
+In both versions however it contains a Value, typed as a Currency,
+which we already know how to binary-encode.
+
+[conid]: https://godoc.org/github.com/rivine/rivine/types#CoinOutputID
+[bsoid]: https://godoc.org/github.com/rivine/rivine/types#BlockStakeOutputID
+[outid]: https://godoc.org/github.com/rivine/rivine/types#OutputID
+[txnid]: https://godoc.org/github.com/rivine/rivine/types#TransactionID
+[blkid]: https://godoc.org/github.com/rivine/rivine/types#BlockID
+
+### Binary Encoding of v1 Transactions
+
+Before we show and explain a full example of a v1 Transaction with some possible input and output types,
+let's see how inputs and outputs are binary-encoded, as the encoding of those are different in
+v1 transactions compared to v0 transactions.
+
+Understanding the following [inputs](#binary-encoding-of-inputs-in-v1-transactions) and [output](#binary-encoding-of-outputs-in-v1-transactions) chapters,
+together with [the Binary Encoding of Types chapter](#the-binary-encoding-of-types),
+should make you able to understand the [Example of a binary-encoded v1 transaction](#example-of-a-binary-encoded-v1-transaction),
+without a sweat.
+
+#### Binary Encoding of Inputs in v1 Transactions
+
+Block stake- and coin- inputs are optional, and both are encoded in the same format:
+
+```plain
++------------+--------------------+--------------------+--------------------+
+| value      | unlock fulfillment | unlock fulfillment | unlock fulfillment |
+| (currency) | type               | data length N      | data               |
++------------+--------------------+--------------------+--------------------+
+| X bytes    | 1 byte             | 8 bytes            | N bytes            |
+```
+
+The value is of type Currency and expressed as a Big Integer. The length depends upon how big it is.
+You can learn how a currency is binary-encoded in [the Binary Encoding of Types chapter](#the-binary-encoding-of-types).
+
+The format of the unlock fulfillment data, and consequently its byte length,
+depends upon the unlock fulfillment type.
+
+##### Binary Encoding of a SingleSignatureFulfillment
+
+The FulfillmentTypeSingleSignature (`0x01`) identifies a SingleSignatureFulfillment
+and has following format:
+
+```plain
++------------+-----------+
+| PublicKey  | Signature |
++------------+-----------+
+| 24+N bytes | M bytes   |
+```
+
+Please read [/doc/transactions/unlockhash.md#public-key-unlock-hash](/doc/transactions/unlockhash.md#public-key-unlock-hash),
+if you want to know how a public key is encoded.
+
+The length of a signature depends upon the signature algorithm used.
+The type of (signature) algorithm is identified by the Algorithm Specifier, encoded as part of the Public Key.
+
+This fulfillment is used to fulfill an UnlockHashCondition (ConditionType `0x01`),
+where the UnlockHash given as part of that condition is of UnlockType `0x01` (implying a PublicKey UnlockHash).
+It is also used to fulfill a TimeLockCondition (ConditionType `0x03`), where the internal condition,
+given as part of the TimeLockCondition is the same kind of UnlockHashCondition as we just discussed.
+
+##### Binary Encoding of an AtomicSwapFulfillment
+
+The FulfillmentTypeAtomicSwap (`0x02`) identifies an AtomicSwapFulfillment
+and can have 2 formats. It can have the new/v1 format, as well as the legacy (v0) format.
+
+The new/v1 format can fulfill only an AtomicSwapCondition (ConditionType `0x02`), and is formatted as follows:
+
+```plain
++------------+-----------+----------+
+| PublicKey  | Signature | Secret   |
++------------+-----------+----------+
+| 24+N bytes | M bytes   | 32 bytes |
+```
+
+The legacy/v0 format can fulfill an AtomicSwapCondition (ConditionType `0x02`) as well,
+but is usually given in order to fulfill an UnlockHashCondition (ConditionType `0x01`),
+where the UnlockHash given as part of that condition is of UnlockType Atomic Swap (`0x02`).
+This legacy format is formatted as follows:
+
+```plain
++---------------------+----------------------+---------------+-----------+------------+--------------+--------------+
+| sender unlock hash  | receiver unlock hash | hashed secret | time lock | PublicKey  | Signature    | Secret       |
+|                     |                      | (byte array)  | (uint64)  |            | (byte slice) | (byte array) |
++---------------------+----------------------+---------------+-----------+------------+--------------+--------------+
+| 33 bytes            | 33 bytes             | 32 bytes      | 8 bytes   | 24+N bytes | M bytes      | 32 bytes     |
+```
+
+Please read [/doc/transactions/unlockhash.md#public-key-unlock-hash](/doc/transactions/unlockhash.md#public-key-unlock-hash),
+if you want to know how a public key is encoded.
+
+The length of a signature depends upon the signature algorithm used.
+The type of (signature) algorithm is identified by the Algorithm Specifier, encoded as part of the Public Key.
+
+#### Binary Encoding of Outputs in v1 Transactions
+
+Block stake- and coin- outputs are optional, and both are encoded in the same format:
+
+```plain
++-----------+------------------+------------------+------------------+
+| outputID  | unlock condition | unlock condition | unlock condition |
+|           | type             | data length N    | data             |
++-----------+------------------+------------------+------------------+
+| 32 bytes  | 1 byte           | 8 bytes          | N bytes          |
+```
+
+The format of the unlock condition data, and consequently its byte length,
+depends upon the unlock condition type.
+
+##### Binary Encoding of a NilCondition
+
+The ConditionTypeNil (`0x00`) identifies a NilCondition
+and has no format, given that its data length is `0x0000000000000000` (`0`).
+
+An output using a NilCondition can be spend anyone who owns a wallet address,
+simply by signing the input with a single signature, using a private key of choice.
+
+##### Binary Encoding of an UnlockHashCondition
+
+The ConditionTypeUnlockHash (`0x01`) identifies an UnlockHashCondition,
+has always a length of `0x2100000000000000` (`33`) and is simply an UnlockHash encoded in binary form.
+
+The details of the binary encoding of an unlock hash are described in
+[/doc/transactions/unlockhash.md](/doc/transactions/unlockhash.md).
+
+Such condition can be fulfilled by proving the ownership of the private key,
+which is linked to the public key from which this unlock hash is derived.
+
+The signature, given as part of the fulfillment, is the proof.
+See [the Signing Transactions chapter](#signing-transactions) for more information.
+
+##### Binary Encoding of an AtomicSwapCondition
+
+The ConditionTypeAtomicSwap (`0x02`) identifies an AtomicSwapCondition,
+has always a length of `0x6a00000000000000` (`106`) and has following format:
+
+```plain
++---------------------+----------------------+---------------+-----------+
+| sender unlock hash  | receiver unlock hash | hashed secret | time lock |
+|                     |                      | (byte array)  | (uint64)  |
++---------------------+----------------------+---------------+-----------+
+| 33 bytes            | 33 bytes             | 32 bytes      | 8 bytes   |
+```
+
+How such condition can be fulfilled depends upon the height or timestamp of the last block in the chain.
+If the contract is active, the condition can be fulfilled by proving the ownership of the private key,
+which is linked to the public key from which the receiver unlock hash is derived. Otherwise the condition
+can be fulfilled by proving the ownerhship of the private key, which is linked to the public key from which
+the sender unlock hash is derived.
+
+The signature, given as part of the fulfillment, is the proof.
+See [the Signing Transactions chapter](#signing-transactions) for more information.
+
+##### Binary Encoding of a TimeLockCondition
+
+The ConditionTypeTimeLock (`0x03`) identifies a TimeLockCondition
+and has following format:
+
+```plain
++----------+------------------+------------------+------------------+
+| LockTime | unlock condition | unlock condition | unlock condition |
+| (uint64) | type             | data length N    | data             |
++----------+------------------+------------------+------------------+
+| 33 bytes | 1 byte           | 8 bytes          | N bytes          |
+```
+
+Such condition is to be fulfilled in 2 parts:
+
++ The first part is done implicitly, by ensuring the last block height or time is less than the height/time specified as LockTime. If the LockTime is less then 500 milion it is to be assumed to be identifying a block height, otherwise it identifies a unix epoch timestamp in seconds;
++ If the first part has been fulfilled, the internal condition has to be fulfilled explicitly, by giving a fulfillment which is able to fulfill the internal condition, which is part of the TimeLockCondition and encoded as the very last thing;
+
+The constant which defines whether a LockTime is a Block Height or a Unix Epoch Timestamp in seconds,
+is `LockTimeMinTimestampValue` and is documented in <https://godoc.org/github.com/rivine/rivine/types#pkg-constants>.
+
+#### Example of a binary-encoded v1 transaction
+
+Complete v1 transaction using multiple coin/blockstake inputs and outputs, as well as arbitrary data:
+
+```plain
+019e0400000000000003000000000000002200000000000000000000000000000000000000000000000000000000000022018000000000000000656432353531390000000000000000002000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff4000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff330000000000000000000000000000000000000000000000000000000000003302a000000000000000656432353531390000000000000000002000000000000000abababababababababababababababababababababababababababababababab4000000000000000dededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededabadabadabadabadabadabadabadabadabadabadabadabadabadabadabadaba4400000000000000000000000000000000000000000000000000000000000044020a01000000000000011234567891234567891234567891234567891234567891234567891234567891016363636363636363636363636363636363636363636363636363636363636363bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb07edb85a00000000656432353531390000000000000000002000000000000000abababababababababababababababababababababababababababababababab4000000000000000dededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededabadabadabadabadabadabadabadabadabadabadabadabadabadabadabadaba030000000000000001000000000000000201210000000000000001cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc01000000000000000301210000000000000002dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd010000000000000004026a00000000000000011234567891234567891234567891234567891234567891234567891234567891016363636363636363636363636363636363636363636363636363636363636363bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb07edb85a0000000001000000000000004400000000000000000000000000000000000000000000000000000000000044018000000000000000656432353531390000000000000000002000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee4000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee010000000000000001000000000000002a01210000000000000001abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd010000000000000001000000000000000102000000000000003432
+```
+
+> Note that not all possible inputs, outputs and variants are shown. See the Inputs- and Outputs chapter from above,
+> to see the binary encoding of all those possible inputs and outputs.
+
+Breakdown:
+
++ `01`: Version One (`0x01`)
++ `9e04000000000000`: length (`1182`) of the transaction data in binary-encoded form
++ `0300000000000000`: amount of coin inputs (`3`)
+  + Coin Input #1:
+    + `2200000000000000000000000000000000000000000000000000000000000022`: parentID (an ID of an unspend coin output)
+    + `01`: Condition Type: UnlockHashCondition
+    + `8000000000000000`: length (`128`) of the UnlockHashCondition in binary-encoded form
+      + `65643235353139000000000000000000`: public key's algorithm specifier (identifying the Ed25519 signature algorithm)
+      + `2000000000000000`: public key (byte) length (`32`)
+      + `ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff`: public key (32 bytes)
+      + `4000000000000000`: signature (byte) length (`64`)
+      + `ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff`: signature (64 bytes)
+  + Coin Input #2:
+    + `3300000000000000000000000000000000000000000000000000000000000033`: parentID (an ID of an unspend coin output)
+    + `02`: Condition Type: AtomicSwapFulfillment (could be in legacy format or the new one, but this one is using the new (v1) format)
+    + `a000000000000000`: length (`160`) of the AtomicSwapFulfillment in binary-encoded form
+      + `65643235353139000000000000000000`: public key's algorithm specifier (identifying the Ed25519 signature algorithm)
+      + `2000000000000000`: public key (byte) length (`32`)
+      + `abababababababababababababababababababababababababababababababab`: public key (32 bytes)
+      + `4000000000000000`: signature (byte) length (`64`)
+      + `dededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededede`: signature (64 bytes)
+      + `dabadabadabadabadabadabadabadabadabadabadabadabadabadabadabadaba`: secret (32 bytes)
+  + Coin Input #3:
+    + `4400000000000000000000000000000000000000000000000000000000000044`: parentID (an ID of an unspend coin output)
+    + `02`: Condition Type: AtomicSwapFulfillment (could be in legacy format or the new one, but this one is using the legacy (v0) format)
+    + `0a01000000000000`: length (`266`) of the AtomicSwapFulfillment in legacy-binary-encoded form
+      + `011234567891234567891234567891234567891234567891234567891234567891`: unlock hash of sender (`0x01` prefix indicated a PubKeyUnlockHash, implying a wallet address)
+      + `016363636363636363636363636363636363636363636363636363636363636363`: unlock hash of receiver (`0x01` prefix indicated a PubKeyUnlockHash, implying a wallet address)
+      + `bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb`: hashed secret (sha256 checksum of secret) (32 bytes)
+      + `07edb85a00000000`: TimeLock, unix epoch seconds timestamp (`1522068743`) on which the atomic swap contract expires
+      + `65643235353139000000000000000000`: public key's algorithm specifier (identifying the Ed25519 signature algorithm)
+      + `2000000000000000`: public key (byte) length (`32`)
+      + `abababababababababababababababababababababababababababababababab`: public key (32 bytes)
+      + `4000000000000000`: signature (byte) length (`64`)
+      + `dededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededabadabadabadabadabadabadabadabadabadabadabadabadabadabadabadaba`: signature (64 bytes)
++ `0300000000000000`: amount of coin outputs (`3`) (does not have to equal the amount of coin outputs, just so you know)
+  + Coin Output #1:
+    + `0100000000000000`: Currency length
+    + `02`: Currency Value (`2`) in smallest Coin Unit
+    + `01`: UnlockConditionType, UnlockHash
+    + `2100000000000000`: byte length (`33`) of UnlockHashCondition in binary-encoded form
+      + `01cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc`: unlockhash of recipient (`0x01` prefix indicated a PubKeyUnlockHash, implying a wallet address)
+  + Coin Output #2:
+    + `0100000000000000`: Currency length
+    + `03`: Currency Value (`3`) in smallest Coin Unit
+    + `01`: UnlockConditionType, UnlockHash
+    + `2100000000000000`: byte length (`33`) of UnlockHashCondition in binary-encoded form
+      + `02dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd`: unlockhash of recipient (`0x02` prefix indicated a AtomicSwapUnlockHash)
+  + Coin Output #3:
+    + `0100000000000000`: Currency length
+    + `04`: Currency Value (`4`) in smallest Coin Unit
+    + `02`: UnlockConditionType, AtomicSwap
+    + `6a00000000000000`: byte length (`106`) of AtomicSwapCondition in binary-encoded form
+      + `011234567891234567891234567891234567891234567891234567891234567891`: unlock hash of sender (`0x01` prefix indicated a PubKeyUnlockHash, implying a wallet address)
+      + `016363636363636363636363636363636363636363636363636363636363636363`: unlock hash of receiver (`0x01` prefix indicates a PubKeyUnlockHash, implying a wallet address)
+      + `bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb`: hashed secret (sha256 checksum of secret)
+      + `07edb85a00000000`: TimeLock, unix epoch seconds timestamp (`1522068743`) on which the atomic swap contract expires
++ `0100000000000000`: amount of block stake inputs (`1`)
+  + Block Stake Input #1:
+    + `4400000000000000000000000000000000000000000000000000000000000044`: parentID (an ID of an unspend block stake output)
+    + `01`: Condition Type: UnlockHashCondition
+    + `8000000000000000`: length (`128`) of the UnlockHashCondition in binary-encoded form
+      + `65643235353139000000000000000000`: public key's algorithm specifier (identifying the Ed25519 signature algorithm)
+      + `2000000000000000`: public key (byte) length (`32`)
+      + `eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee`: public key (32 bytes)
+      + `4000000000000000`: signature (byte) length (`64`)
+      + `eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee`: signature (64 bytes)
++ `0100000000000000`: amount of block stake outputs (`1`)
+  + Block Stake Output #1:
+    + `0100000000000000`: Currency length
+    + `2a`: Currency Value (`42`) expressed in units of block stakes
+    + `01`: UnlockConditionType, UnlockHash
+    + `2100000000000000`: byte length of UnlockHashCondition in binary-encoded form
+      + `01abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd`: unlockhash of recipient (`0x01` prefix indicated a PubKeyUnlockHash, implying a wallet address)
++ `0100000000000000`: amount of miner fees (`1`)
+  + Miner Fee #1:
+    + `0100000000000000`: Currency length
+    + `01`: Currency Value (`1`) in smallest Coin Unit
++ `0200000000000000`: Arbitrary data byte length (`2`)
+  + `3432`: Arbitrary Data (`"42"`)
+
+### Binary Encoding of v0 Transactions
+
+Before we show and explain a full example of a v0 Transaction with all possible input and output types,
+let's see how inputs and outputs are binary-encoded, as the encoding of those are different in
+v0 transactions compared to v1 transactions.
+
+Understanding the following [inputs](#binary-encoding-of-inputs-in-v0-transactions) and [outputs](#binary-encoding-of-outputs-in-v0-transactions) chapters,
+toghether with [the Binary Encoding of Types chapter](#the-binary-encoding-of-types),
+should make you able to understand the [Example of a binary-encoded v0 transaction](#example-of-a-binary-encoded-v0-transaction),
+without a sweat.
+
+#### Binary Encoding of Inputs in v0 Transactions
+
+Block stake- and coin- inputs are optional, and both are encoded in the same format:
+
+```plain
 +-----------+------------------+
-| output ID | input lock       |
+| outputID  | input lock       |
 +-----------+------------------+
 | 32 bytes  | X bytes          |
 ```
 
-The encoding details of output ID is discused in [the others section](#others).
-
 Where the input lock is encoded as:
 
-```
+```plain
 +--------+-----------+-------------+
 | type   | condition | fulfillment |
 +--------+-----------+-------------+
@@ -388,13 +1275,13 @@ Where the input lock is encoded as:
 ```
 
 Both condition and fulfillment are encoded as a raw binary (byte) slice,
-and therefore, as you should know by now, are prefixed by the length (a 8 bytes unsigned integer).
+and therefore, as you should know by now, are prefixed by the length.
 
 While the encoding of the condtion and fulfillment slices are dependent upon the type,
 indicated by the byte prefix, the unlock hash (defined in the output defined by the earlier given output ID)
 can be computed without having to decode the different parts of the input lock:
 
-```
+```plain
 hash = blake2b_checksum256(binary_encoded_condition)
 unlockHash = single_byte_unlock_type + hash
 ```
@@ -404,43 +1291,28 @@ Please read about the binary encoding of the unlockhash at
 should you not understand the formula given above.
 
 As the condition and fulfillment parts are encoded as byte slices,
-their encoded form will be at least 9 bytes, and usually a lot more.
+their encoded form will be at least 8 bytes, and usually a lot more.
 
-The only currently known types are:
+The only supported types are:
 
 + `0x01`: Single Signature
 + `0x02`: Atomic Swap Contract
 
-Other types can be added by means of a soft-fork,
-but as long as block creator nodes on the network do not support these types,
-they'll not be able to be added to the blockchain as part of a block.
+As v0 transactions are legacy, no other types will ever be added.
 
 ##### Single Signature
 
 When the type (prefix) byte of an input lock equals to `0x01`,
 it should be assumed that a single-signature input lock is used for the unspend output.
-This also means that the first 2 bytes of the unlockhash of that output should equal `"01"`.
+This also means that the first byte of the unlockhash of that output should equal `0x01`.
 
-The conditon, equals the receiver's public key, and is encoded as:
-
-```
-+---------------------+------------+
-| algorithm specifier | key        |
-+---------------------+------------+
-| 16 bytes            | 8+N bytes  |
-```
-
-The public key is encoded as a slice,
-which length (N) depends upon the algorithm used.
-
-The algorithm is identified by the 16 bytes algorithm specifier,
-and currently the only known/supported algorithm is `"ed25519\0\0\0\0\0\0\0\0\0"`,
-in which case the public key size is 32 bytes (`N=32`), and therefore the condition
-will have a byte (slice) size of 56 bytes (`16+8+32`) for ed25519 signatures.
+The conditon, equals the receiver's public key.
+See [/doc/transactions/unlockhash.md#public-key-unlock-hash](/doc/transactions/unlockhash.md#public-key-unlock-hash)
+to know how a public key is encoded.
 
 The fulfillment is encoded as:
 
-```
+```plain
 +-----------+
 | signature |
 +-----------+
@@ -448,55 +1320,22 @@ The fulfillment is encoded as:
 ```
 
 Where the exact byte size will depend on the signature algorithm used,
-indicated by the public key's specifier.
+indicated by the public key's (algorithm) specifier.
 
 There is currently only one known specifier, `"ed25519\0\0\0\0\0\0\0\0\0"`,
 which signature size is 64 bytes, generated using a private key of 64 bytes.
 
-In this only known/supported signature algorithm (`ed25519`),
-the signature is computed/signed using `ed25519_sign(message, privateKey)`,
-where message is `blake2b_sum256(encoded_object`), where `encoded_object` is formatted as:
-
-```
-+-------------+-------------+--------------+-------------------+
-| input index | coin inputs | coin outputs | blockstake inputs | ...
-+-------------+-------------+--------------+-------------------+
-| 8 bytes     |             |              |                   |
-
-    +--------------------+------------+----------------+
-... | blockstake outputs | miner fees | arbitrary data |
-    +--------------------+------------+----------------+
-    |                    |            | 8+ bytes       |
-```
-
-The encoding of coin/blockstake outputs, miner fees and arbtirary data
-have already been discussed earlier in this document. Input index is encoded as
-a 64-bit unsigned integer and represents the sequential position the input has
-within the coin/blockstake input slice.
-
-For this encoding only, each coin- and block stake input is encoded as:
-
-```
-+----------+-------------+
-| ParentID | unlock hash |
-+----------+-------------+
-| 32 bytes | 33 bytes    |
-```
-
-The ParentID is an output identifier, as discussed in [the output identifier section](#output-identifiers). 
-
-As usual, the details of binary encoding of an unlock hash can
-be read at [/doc/transactions/unlockhash.md](/doc/transactions/unlockhash.md).
+See [the Signing a V0 Transactions chapter](#signing-a-v0-transaction) to know how this signature is created.
 
 ##### Atomic Swap Contract
 
 When the type (prefix) byte of an input lock equals to `0x02`,
-it should be assumed that a single-signature input lock is used for the unspend output.
-This also means that the first 2 bytes of the unlockhash of that output should equal `"02"`.
+it should be assumed that a atomic-swap input lock is used for the unspend output.
+This also means that the first byte of the unlockhash of that output should equal `0x02`.
 
 The conditon is encoded as:
 
-```
+```plain
 +---------------------+----------------------+---------------+-----------+
 | sender unlock hash  | receiver unlock hash | hashed secret | time lock |
 +---------------------+----------------------+---------------+-----------+
@@ -506,238 +1345,67 @@ The conditon is encoded as:
 As usual, the details of binary encoding of an unlock hash can
 be read at [/doc/transactions/unlockhash.md](/doc/transactions/unlockhash.md).
 
-The hashed secret is 32 bytes, and is a sha256 crypto hash with as input the 32-byte secret. The timelock is a Unix timestamp in seconds, encoded as a 64 bit unsigned integer.
+The hashed secret is 32 bytes, and is a sha256 crypto hash with as input the 32-byte secret.
+The timelock is a Unix timestamp in seconds, encoded as a 64 bit unsigned integer.
 
-```
+The fulfillment is encoded as:
+
+```plain
 +---------------------+------------+-----------+----------+
 | algorithm specifier | public key | signature | secret   |
 +---------------------+------------+-----------+----------+
 | 16 bytes            | 8+N bytes  | 8+M bytes | 32 bytes |
 ```
 
-The public key (algo specifier + public key) has already been discussed before.
-Just to be clear: the specifier is for now always assumed to be `"ed25519\0\0\0\0\0\0\0\0\0"`, than the key itself is encoded. However as that is just a byte slice, we first encode the length (N) as an 64-bit unsigned integer, and only than N bytes for the key itself. for `ed25519` the public key size (N) is always 32.
+The encoding of a public key is explained in
+[/doc/transactions/unlockhash.md#public-key-unlock-hash](/doc/transactions/unlockhash.md#public-key-unlock-hash).
 
-The signature depends upon the algorithm specifier as well, and is for `ed25519` 64 bytes, meaning that `64` will be encoded as a 64-bit unsigned integer, and than the 64 bytes of the `ed25519` signature itself.
+The signature depends upon the algorithm specifier as well,
+and is 64 bytes when using the `ed25519` signature algorithm used.
+What signature algorithm is used is defined by the given Public Key.
 
-The secret has no specific format and only has a byte-length of 32.
+The secret has no specific format and has a fixed byte-length of 32,
+and is assumed to be random in a crypto-secure manner.
 
-The signature is always generated using the formula:
+See [the Signing a V0 Transactions chapter](#signing-a-v0-transaction) to know how this signature is created.
 
-```
-signature = crypto_sign_algo(message: blake2b_256(encoded_object), private_key)
-```
+#### Binary Encoding of Outputs in v0 Transactions
 
-What crypto sign(ature) algorithm is used,
-depends upon the algorithm specifier of the to be used
-public key (given as part of the same fulfillment).
-Similarly, the size of the private_key is fixed but
-also depends upon that same algorithm specifier.
+The format of coin- and blockstake- outputs are the same:
 
-The `encoded_object` is encoded as follows:
-
-```
-+-------------+-------------+--------------+-------------------+
-| input index | coin inputs | coin outputs | blockstake inputs | ...
-+-------------+-------------+--------------+-------------------+
-| 8 bytes     |             |              |                   |
-
-    +--------------------+------------+----------------+------------+----------+
-... | blockstake outputs | miner fees | arbitrary data | public key | secret   |
-    +--------------------+------------+----------------+------------+----------+
-    |                    |            | 8+ bytes       |            | 32 bytes |
+```plain
++----------+----------+-----+----------+
+| length N | output#1 | ... | output#N |
++----------+----------+-----+----------+
+| 8 bytes  | where each output is      |
+|          | 87 bytes or more          |
 ```
 
-Input index, the zero-index indicating the position of the coin/blockstake input within the transaction's coin/blockstake input slice, is an integer and thus as usual encoded as an unsigned 64 bit integer.
-Earlier in this document is already explained how coin outputs, blockstake outputs,
-miner fees and arbitrary data are encoded.
+Where each output is encoded as:
 
-he 32 bytes of the secret are simply copied, and no further encoding is applied.
-The secret part isn't used as part of the atomic swap's condition,
-in case the public key is owned by the sender, or in other words,
-the locked output is used as a refund input
-
-Coin inputs and block stake inputs are in this case encoded in the following way:
-
-```
-+------------------+-------------------+
-| parent output ID | input unlock hash |
-+------------------+-------------------+
-| 32 bytes         | 33 bytes          |
+```plain
++--------------------------------------+-------------+
+| currency (big integer)               | unlock hash |
++--------------------------------------+-------------+
+| length N     | big integer (N bytes) | (33 bytes)  |
+| (8 bytes)    |   absolute value &    |             |
+|              |   big endian          |             |
 ```
 
-Parent output ID is a 32 byte hash, computed as a blake2b 256bit checksum.
-The details of binary encoding of an (input) unlock hash can
-be read at [/doc/transactions/unlockhash.md](/doc/transactions/unlockhash.md).
+The details of the binary encoding of an unlock hash are described in
+[/doc/transactions/unlockhash.md](/doc/transactions/unlockhash.md).
 
-The encoding details of (parent) output ID is discused in [the others section](#others).
+#### Example of a binary-encoded v0 transaction
 
-The encoding of the public key has already been discussed earlier, but just to repeat:
+Complete v0 transaction using multiple coin/blockstake inputs and outputs, as well as arbitrary data:
 
-```
-+---------------------+------------+
-| algorithm specifier | key        |
-+---------------------+------------+
-| 16 bytes            | 8+N bytes  |
-```
-
-The public key is encoded as a slice,
-which length (N) depends upon the algorithm used.
-
-The algorithm is identified by the 16 bytes algorithm specifier,
-and currently the only known/supported algorithm is `"ed25519\0\0\0\0\0\0\0\0\0"`,
-in which case the public key size is 32 bytes (`N=32`), and therefore the condition
-will have a byte (slice) size of 56 bytes (`16+8+32`) for ed25519 signatures.
-
-#### others
-
-In this section we'll discuss the details/format/encoding of anything else relevant.
-
-##### Output Identifiers
-
-All output identifiers are computed the same way,
-with the only difference the (prefix) 16 byte specifier used.
-Possible output identifiers are coinOutputID and blockstakeOutputID.
-With that said, here is how an output ID is formatted:
-
-```
-+----------+
-| hash     |
-+----------+
-| 32 bytes |
-```
-
-That's it! Just a 32 byte (blake2b, 256 bit) crypto hash. Simple.
-
-But what is used as input message for the blake2b_256 hash?
-Glad you asked. The message is binary encoded and formatted as:
-
-```
-+-----------+-------------+--------------+-------------------+--------------------+
-| specifier | coin inputs | coin outputs | blockstake inputs | blockstake outputs | ...
-+-----------+-------------+--------------+-------------------+--------------------+
-| 16 bytes  |             |              |                   |                    |
-
-    +------------+----------------+--------------+
-... | miner fees | arbitrary data | output index |
-    +------------+----------------+--------------+
-    |            | 8+ bytes       | 8 bytes      |
-```
-
-The encoding of coin/blockstake inputs/outputs, miner fees and arbtirary data
-have already been discussed earlier in this document. Output index is encoded as
-a 64-bit unsigned integer and represents the sequential position the output has
-within the coin/blockstake output slice.
-
-Specifier defines what kind of outputID it is and is one of following:
-
-+ `"coin output\0\0\0\0\0"`: coin output ID
-+ `"blstake output\0\0"`: blockstake output ID
-
-##### Unlock hash's hash
-
-As can be read in [/doc/transactions/unlockhash.md](/doc/transactions/unlockhash.md),
-an unlock hash text encoding consists out of 3 parts: type, hash and checksum (of hash).
-
-But how is that hash generated? Well, using the blake2b 256-bit algorithm,
-we compute a 32-byte crypto hash, using the binary encoding of
-the relevant input's unlock condition as hash input.
-
-How the unlock condition is binary encoded depends upon the unlock type used
-(and defined in both the input as well as the output,
-where it is the prefix of the unlock hash in the latter case).
-For unknown types the unlock condition is opaque and binary, and thus nothing has to be done if so.
-
-When the unlock type is of a known type however, the enoding will depend on this type.
-
-You can read more about how each unlock type's condition is binary encoded
-in [the inputs section](#inputs).
-
-### examples
-
-In this example we'll explain a couple of example binary encoded transactions
-in detail, byte by byte, as to summarize everything discussed in this document so far.
-
-All examples are also unit tested as part of this Golang reference implementation of Rivine,
-as to help ensuring that the documentation stays in sync with the code.
-You can find the unit tests for all examples listed below
-as `TestTransactionEncodingDocExamples` in [/types/transactions_test.go](/types/transactions_test.go).
-
-#### transaction with one single signature coin input and no outputs
-
-Encoded transaction in hex format:
-
-```
-0001000000000000002200000000000000000000000000000000000000000000000000000000000022013800000000000000656432353531390000000000000000002000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff4000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000000000000000000000000000000000000000000000001000000000000000100000000000000010000000000000000
-```
-
-Breakdown:
-
-+ `00` (version One, `0x00`)
-+ `0100000000000000` (coin inputs, length `1` in little endian, 8 bytes):
-  + `2200000000000000000000000000000000000000000000000000000000000022` (coinOutputID, 32 bytes, crypto Hash)
-  + `01` (input lock type, SingleSignature (`0x01`)):
-    + `3800000000000000` (condition length: `48` in little endian, 8 bytes):
-      + `65643235353139000000000000000000` (public key, algorithm specifier `ed25519`)
-      + `2000000000000000` (public key, key length `32`)
-        + `ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff` (public key, key itself, 32 bytes)
-    + `4000000000000000` (fulfillment length: `64`, in little endian, 8 bytes):
-      + `ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff` (ed25519 signature, 64 bytes)
-+ `0000000000000000` (coin outputs, length `0`, in little endian, 8 bytes)
-+ `0000000000000000` (blockstake inputs, length `0`, in little endian, 8 bytes)
-+ `0000000000000000` (blockstake outputs, length `0`, in little endian, 8 bytes)
-+ `0100000000000000` (miner fees, length `1`, in little endian, 8 bytes):
-  + `0100000000000000` (currency, length `1`, in little endian, 8 bytes):
-    + `01` (currency value `1`, in big endian, 1 byte)
-+ `0000000000000000` (arbitrary data, length `0`, in little endian, 8 bytes)
-
-
-#### transaction with one signle signature coin input and a couple of coin outputs
-
-```
-0001000000000000002200000000000000000000000000000000000000000000000000000000000022013800000000000000656432353531390000000000000000002000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff4000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff 0200000000000000 0100000000000000 02 01 cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc01000000000000000301dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd0000000000000000000000000000000001000000000000000100000000000000010000000000000000
-```
-
-Breakdown:
-
-+ `00` (version One, `0x00`)
-+ `0100000000000000` (coin inputs, length `1` in little endian, 8 bytes):
-  + `2200000000000000000000000000000000000000000000000000000000000022` (coinOutputID, 32 bytes, crypto Hash)
-  + `01` (input lock type, SingleSignature (`0x01`)):
-    + `3800000000000000` (condition length: `48` in little endian, 8 bytes):
-      + `65643235353139000000000000000000` (public key, algorithm specifier `ed25519`)
-      + `2000000000000000` (public key, key length `32`)
-        + `ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff` (public key, key itself, 32 bytes)
-    + `4000000000000000` (fulfillment length: `64`, in little endian, 8 bytes):
-      + `ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff` (ed25519 signature, 64 bytes)
-+ `0200000000000000` (coin outputs, length `2`, in little endian, 8 bytes):
-  + first:
-    + `0100000000000000` (currency, length `1`, in little endian, 8 bytes):
-      + `02` (currency, value `2`, in big endian)
-    + `01` (unlock hash, unlock type `0x01`, single byte):
-      + `cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc` (unlock hash, crypto hash, 32 bytes)
-  + second:
-    + `0100000000000000` (currency, length `1`, in little endian, 8 bytes):
-      + `03` (currency, value `3`, in big endian)
-    + `01` (unlock hash, unlock type `0x01`, single byte):
-      + `dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd` (unlock hash, crypto hash, 32 bytes)
-+ `0000000000000000` (blockstake inputs, length `0`, in little endian, 8 bytes)
-+ `0000000000000000` (blockstake outputs, length `0`, in little endian, 8 bytes)
-+ `0100000000000000` (miner fees, length `1`, in little endian, 8 bytes):
-  + `0100000000000000` (currency, length `1`, in little endian, 8 bytes):
-    + `01` (currency, value `1`, in big endian)
-+ `0000000000000000` (arbitrary data, length `0`, in little endian, 8 bytes)
-
-#### complete transaction multiple coin/blockstake inputs and outputs, as well as arbitrary data
-
-```
+```plain
 0002000000000000002200000000000000000000000000000000000000000000000000000000000022013800000000000000656432353531390000000000000000002000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff4000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3300000000000000000000000000000000000000000000000000000000000033026a00000000000000011234567891234567891234567891234567891234567891234567891234567891016363636363636363636363636363636363636363636363636363636363636363bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb07edb85a00000000a000000000000000656432353531390000000000000000002000000000000000abababababababababababababababababababababababababababababababab4000000000000000dededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededabadabadabadabadabadabadabadabadabadabadabadabadabadabadabadaba020000000000000001000000000000000201cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc01000000000000000302dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd01000000000000004400000000000000000000000000000000000000000000000000000000000044013800000000000000656432353531390000000000000000002000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee4000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee010000000000000001000000000000002a01abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd010000000000000001000000000000000102000000000000003432
 ```
 
-
 Breakdown:
 
-+ `00` (version One, `0x00`)
++ `00` (version Zero, `0x00`)
 + `0200000000000000` (coin inputs, length `2` in little endian, 8 bytes):
   + first:
     + `2200000000000000000000000000000000000000000000000000000000000022` (coinOutputID, 32 bytes, crypto Hash)
@@ -746,7 +1414,7 @@ Breakdown:
         + `65643235353139000000000000000000` (public key, algorithm specifier `ed25519`)
         + `2000000000000000` (public key, key length `32`)
           + `ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff` (public key, key itself, 32 bytes)
-      + `4000000000000000` (fulfillment length: `64`, in little endian, 8 bytes):
+      + `4000000000000000` (fulfillment length: `64`, 8 bytes):
         + `ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff` (ed25519 signature, 64 bytes)
   + second:
     + `3300000000000000000000000000000000000000000000000000000000000033` (coinOutputID, 32 bytes, crypto Hash)
@@ -760,25 +1428,25 @@ Breakdown:
           + `6363636363636363636363636363636363636363636363636363636363636363` (unlock hash, crypto hash, 32 bytes)
         + `bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb` (hashed secret, 32 bytes, sha256_checksum)
         + `07edb85a00000000` (timelock, unix epoch time in seconds, 1522068743)
-      + `a000000000000000` (fulfillment length: `160`, in little endian, 8 bytes):
+      + `a000000000000000` (fulfillment length: `160`, 8 bytes):
         + `65643235353139000000000000000000` (public key, algorithm specifier `ed25519`)
         + `2000000000000000` (public key, key length `32`)
           + `abababababababababababababababababababababababababababababababab` (public key, key itself, 32 bytes)
         + `4000000000000000` (ed25519 signature length `64` in little endian, 8 bytes):
           + `dededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededede` (ed25519 signature, 64 bytes)
-       + `dabadabadabadabadabadabadabadabadabadabadabadabadabadabadabadaba` (secret, 32 bytes, fixed size)
-+ `0200000000000000` (coin outputs, length `2`, in little endian, 8 bytes):
+        + `dabadabadabadabadabadabadabadabadabadabadabadabadabadabadabadaba` (secret, 32 bytes, fixed size)
++ `0200000000000000` (coin outputs, length `2`):
   + first:
-    + `0100000000000000` (currency, length `1`, in little endian, 8 bytes):
+    + `0100000000000000` (currency, length `1`):
       + `02` (currency, value `2`, in big endian)
     + `01` (unlock hash, unlock type `0x01`, single byte):
       + `cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc` (unlock hash, crypto hash, 32 bytes)
   + second:
-    + `0100000000000000` (currency, length `1`, in little endian, 8 bytes):
+    + `0100000000000000` (currency, length `1`):
       + `03` (currency, value `3`, in big endian)
     + `01` (unlock hash, unlock type `0x01`, single byte):
       + `dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd` (unlock hash, crypto hash, 32 bytes)
-+ `0100000000000000` (blockstake inputs, length `1`, in little endian, 8 bytes):
++ `0100000000000000` (blockstake inputs, length `1`):
   + first:
     + `4400000000000000000000000000000000000000000000000000000000000044` (blockStakeOutputID, crypto Hash, 32 bytes)
     + `01` (input lock type, SingleSignature (`0x01`)):
@@ -786,16 +1454,157 @@ Breakdown:
         + `65643235353139000000000000000000` (public key, algorithm specifier `ed25519`)
         + `2000000000000000` (public key, key length `32`)
           + `eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee` (public key, key itself, 32 bytes)
-      + `4000000000000000` (fulfillment length: `64`, in little endian, 8 bytes):
+      + `4000000000000000` (fulfillment length: `64`):
         + `eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee` (ed25519 signature, 64 bytes)
-+ `0100000000000000` (blockstake outputs, length `1`, in little endian, 8 bytes):
++ `0100000000000000` (blockstake outputs, length `1`):
   + first:
-    + `0100000000000000` (currency, length `1`, in little endian, 8 bytes):
-     + `2a` (currency, value `42`, in big endian)
+    + `0100000000000000` (currency, length `1`):
+      + `2a` (currency, value `42`, in big endian)
     + `01` (unlock hash, unlock type `0x01`, SingleSignature):
       + `abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd` (unlock hash, crypto hash, 32 bytes)
-+ `0100000000000000` (miner fees, length `1`, in little endian, 8 bytes):
-  + `0100000000000000` (currency, length `1`, in little endian, 8 bytes):
++ `0100000000000000` (miner fees, length `1`):
+  + `0100000000000000` (currency, length `1`):
     + `01` (currency, value `1`, in big endian)
-+ `0200000000000000` (arbitrary data, length `2`, in little endian, 8 bytes):
++ `0200000000000000` (arbitrary data, length `2`):
   + `3432` (arbitrary data `"42"`)
+
+## Signing Transactions
+
+### Introduction to Signing Transactions
+
+In this chapter we'll assume that signatures are created using the Ed25519 algorithm,
+as that is for now the only signature algorithm supported by the Rivine protocol.
+
+The signature gets created using a private key, which for the Ed25519 algorithm is a fixed 64-byte key,
+and a byte-slice message, which for the Rivine Protocol is, unless otherwise noted, a 32-byte crytographic hash,
+which is a hash created using the [blake2b 256-bit algorithm][blake2b].
+
+Therefore in order to understand signing, you'll need to know how the binary encoding works in the Rivine Protocol.
+Reading, and understanding, [the Binary Encoding chapter](#binary-encoding) and all its subchapters is therefore really important.
+
+Verification of a signature is done in 2 steps:
+
++ First the cryptographic hash is created, the same one that was used as input for the creation of that signature;
++ Using the verification Ed25519 algorithm, the signature is checked, using the newly computed hash (which is assumed to be used as input of the to be check signature), against the public key (a 32-byte sized key for the Ed25519 algorithm) that is linked to the private key that is assumed to be used;
+
+### Signing a v1 Transaction
+
+In order to sign a v1 transaction, you first need to compute the hash,
+which is used as message, which we'll than to create a signature using the Ed25519 algorithm.
+
+Computing that hash can be represented by following pseudo code:
+
+```plain
+blake2b_256_hash(BinaryEncoding(
+  - transactionVersion: byte,
+  - inputIndex: int64 (8 bytes, little endian),
+  extraObjects:
+    if atomicSwap:
+      SiaPublicKey:
+        - Algorithm: 16 bytes fixed-size array
+        - Key: 8 bytes length + n bytes
+    if atomicSwap as claimer (owner of receiver pub key):
+      - Secret: 32 bytes fixed-size array
+  - length(coinInputs): int64 (8 bytes, little endian)
+  for each coinInput:
+    - parentID: 32 bytes fixed-size array
+  - length(coinOutputs): int64 (8 bytes, little endian)
+  for each coinOutput:
+    - value: Currency (8 bytes length + n bytes, little endian encoded)
+    - binaryEncoding(condition)
+  - length(blockStakeInputs): int64 (8 bytes, little endian)
+  for each blockStakeInput:
+    - parentID: 32 bytes fixed-size array
+  - length(blockStakeOutputs): int64 (8 bytes, little endian)
+  for each blockStakeOutput:
+    - value: Currency (8 bytes length + n bytes, little endian encoded)
+    - binaryEncoding(condition)
+  - length(minerFees): int64 (8 bytes, little endian)
+  for each minerFee:
+    - fee: Currency (8 bytes length + n bytes, little endian encoded)
+  - arbitraryData: 8 bytes length + n bytes
+)) : 32 bytes fixed-size crypto hash
+```
+
+BinaryEncoding encodes all bytes as described above,
+concatenating all output bytes together, in order as given.
+The total output byte slice (result of encoding and concatenation)
+is used as the input to make the crypto hashsum using [the blake2b 256bit algorithm][blake2b],
+resulting in a fixed 32-byte array.
+
+The binary encoding of an output condition depends upon the unlock condition type:
+
++ ConditionTypeNil: 0x000000000000000000 (type 0 as 1 byte + length 0 as 8 bytes)
++ ConditionTypeUnlockHash:
+  + 0x01: 1, 1 byte (type)
+  + 0x2100000000000000: 21, 8 bytes (length of unlockHash)
+  + unlockHash: 33 bytes fixed-size array
++ ConditionTypeAtomicSwap:
+  + 0x02: 2, 1 byte (type)
+  + 0x6a00000000000000: 106, 8 bytes (length of following condition properties)
+  + sender (unlockHash): 33 bytes fixed-size array
+  + receiver (unlockHash): 33 bytes fixed-size array
+  + hashedSecret: 32 bytes fixed-size array
+  + timeLock: uint64 (8 bytes, little endian)
++ ConditionTypeTimeLock:
+  + 0x03: 3, 1 byte (type)
+  + length(conditionProperties): int64 (8 bytes, little endian)
+  + lockTime: uint64 (8 bytes, little endian)
+  + binaryEncoding(condition)
+
+A TimeLock wraps around another condition.
+For now the only valid condition type that can be used as the internal
+condition of a TimeLock is a `ConditionTypeUnlockHash`.
+A future version however might also allow other internal condition,
+if so, this document will be updated as well to clarify that.
+
+See [the Binary Encoding of v1 Transactions chapter](#binary-encoding-of-v1-transactions) for more information.
+
+### Signing a v0 Transaction
+
+In order to sign a v0 transaction, you first need to compute the hash,
+which is used as message, which we'll than to create a signature using the Ed25519 algorithm.
+
+Computing that hash can be represented by following pseudo code:
+
+```plain
+blake2b_256_hash(BinaryEncoding(
+  - inputIndex: int64 (8 bytes, little endian),
+  extraObjects:
+    if atomicSwap:
+      SiaPublicKey:
+        - Algorithm: 16 bytes fixed-size array
+        - Key: 8 bytes length + n bytes
+    if atomicSwap as claimer (owner of receiver pub key):
+      - Secret: 32 bytes fixed-size array
+  for each coinInput:
+    - parentID: 32 bytes fixed-size array
+    - unlockHash: 33 bytes fixed-size array
+  - length(coinOutputs): int64 (8 bytes, little endian)
+  for each coinOutput:
+    - value: Currency (8 bytes length + n bytes, little endian encoded)
+    - unlockHash: 33 bytes fixed-size array
+  for each blockStakeInput:
+    - parentID: 32 bytes fixed-size array
+    - unlockHash: 33 bytes fixed-size array
+  - length(blockStakeOutputs): int64 (8 bytes, little endian)
+  for each blockStakeOutput:
+    - value: Currency (8 bytes length + n bytes, little endian encoded)
+    - unlockHash: 33 bytes fixed-size array
+  - length(minerFees): int64 (8 bytes, little endian)
+  for each minerFee:
+    - fee: Currency (8 bytes length + n bytes, little endian encoded)
+  - arbitraryData: 8 bytes length + n bytes
+)) : 32 bytes fixed-size crypto hash
+```
+
+BinaryEncoding encodes all bytes as described above,
+concatenating all output bytes together, in order as given.
+The total output byte slice (result of encoding and concatenation)
+is used as the input to make the crypto hashsum using [the blake2b 256bit algorithm][blake2b],
+resulting in a fixed 32-byte array.
+
+See [the Binary Encoding of v0 Transactions chapter](#binary-encoding-of-v0-transactions) for more information.
+
+[litend]: https://en.wikipedia.org/wiki/Endianness#Little-endian
+[blake2b]: http://blake2.net

--- a/types/signatures_doc_test.go
+++ b/types/signatures_doc_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/rivine/rivine/encoding"
 )
 
-// TestLegacyInputSigHash tests the legacy input signature hash algorithm.
+// TestInputSigHash tests the legacy input signature hash algorithm.
 // It is the algorithm used to compute a signature for an input within a v0 transaction.
 //
 // Pseudo code of signature algorithm, as documented:

--- a/types/signatures_doc_test.go
+++ b/types/signatures_doc_test.go
@@ -1,0 +1,572 @@
+package types
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/rivine/rivine/crypto"
+	"github.com/rivine/rivine/encoding"
+)
+
+// TestLegacyInputSigHash tests the legacy input signature hash algorithm.
+// It is the algorithm used to compute a signature for an input within a v0 transaction.
+//
+// Pseudo code of signature algorithm, as documented:
+//
+//    blake2b_256_hash(BinaryEncoding(
+//      - transactionVersion: byte,
+//      - inputIndex: int64 (8 bytes, little endian),
+//      extraObjects:
+//        if atomicSwap:
+//          SiaPublicKey:
+//            - Algorithm: 16 bytes fixed-size array
+//            - Key: 8 bytes length + n bytes
+//        if atomicSwap as claimer (owner of receiver pub key):
+//          - Secret: 32 bytes fixed-size array
+//      - length(coinInputs): int64 (8 bytes, little endian)
+//      for each coinInput:
+//        - parentID: 32 bytes fixed-size array
+//      - length(coinOutputs): int64 (8 bytes, little endian)
+//      for each coinOutput:
+//        - value: Currency (8 bytes length + n bytes, little endian encoded)
+//        - binaryEncoding(condition)
+//      - length(blockStakeInputs): int64 (8 bytes, little endian)
+//      for each blockStakeInput:
+//        - parentID: 32 bytes fixed-size array
+//      - length(blockStakeOutputs): int64 (8 bytes, little endian)
+//      for each blockStakeOutput:
+//        - value: Currency (8 bytes length + n bytes, little endian encoded)
+//        - binaryEncoding(condition)
+//      - length(minerFees): int64 (8 bytes, little endian)
+//      for each minerFee:
+//        - fee: Currency (8 bytes length + n bytes, little endian encoded)
+//      - arbitraryData: 8 bytes length + n bytes
+//    )) : 32 bytes fixed-size crypto hash
+//
+// BinaryEncoding encodes all bytes as described above,
+// concatenating all output bytes together, in order as given.
+// The total output byte slice (result of encoding and concatenation)
+// is used as the input to make the crypto hashsum using the blake2b 256bit algorithm,
+// resulting in a 32 bytes fixed-size crypto hash.
+//
+// The binary encoding of an output condition depends upon the unlock condition type:
+//
+//   ConditionTypeNil: 0x000000000000000000 (type 0 as 1 byte + length 0 as 8 bytes)
+//   ConditionTypeUnlockHash:
+//     - 0x01: 1, 1 byte (type)
+//     - 0x2100000000000000: 21, 8 bytes (length of unlockHash)
+//     - unlockHash: 33 bytes fixed-size array
+//   ConditionTypeAtomicSwap:
+//     - 0x02: 2, 1 byte (type)
+//     - 0x6a00000000000000: 106, 8 bytes (length of following condition properties)
+//     - sender (unlockHash): 33 bytes fixed-size array
+//     - receiver (unlockHash): 33 bytes fixed-size array
+//     - hashedSecret: 32 bytes fixed-size array
+//     - timeLock: uint64 (8 bytes, little endian)
+//   ConditionTypeTimeLock:
+//     - 0x03: 3, 1 byte (type)
+//     - length(conditionProperties): int64 (8 bytes, little endian)
+//     - lockTime: uint64 (8 bytes, little endian)
+//     - binaryEncoding(condition)
+//
+// A TimeLock wraps around another condition.
+// For now the only valid condition type that can be used as the internal
+// condition of a TimeLock is a ConditionTypeUnlockHash.
+// A future version however might also allow other internal condition.
+//
+// See /doc/Encoding.md for more information
+// about the Binary Encoding Algorithm and how each (primitive) type is encoded.
+//
+// ENSURE TO KEEP THIS TEST UP TO DATE WITH BOTH THE IMPLEMENTATION
+// AS WELL AS THE EXTERNAL (/doc/**/*) DOCUMENTATION !!
+func TestInputSigHash(t *testing.T) {
+	// utility funcs
+	hbs := func(str string) []byte { // hexStr -> byte slice
+		bs, err := hex.DecodeString(str)
+		if err != nil {
+			t.Error(err)
+		}
+		return bs
+	}
+	hs := func(str string) (hash crypto.Hash) { // hbs -> crypto.Hash
+		copy(hash[:], hbs(str))
+		return
+	}
+	sliceToHex := func(b []byte) string {
+		return hex.EncodeToString(b[:])
+	}
+
+	// deterministic private/public key pair
+	var entropy [crypto.EntropySize]byte
+	b, err := hex.DecodeString("5722127ae85b120d15d5998d7591a603f4cbe2ac47a69b4d16bd7c90e21aeedd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	copy(entropy[:], b[:])
+	sk, rpk := crypto.GenerateKeyPairDeterministic(entropy)
+	pk := Ed25519PublicKey(rpk)
+
+	// deterministic atomic swap secret
+	var secret AtomicSwapSecret
+	b, err = hex.DecodeString("8a1ed1737c0a84598bbf429ba351e03b5f4e00d7ab5d8635da832957f14bb272")
+	if err != nil {
+		t.Fatal(err)
+	}
+	copy(secret[:], b[:])
+	hashedSecret := NewAtomicSwapHashedSecret(secret)
+
+	// signature computation algo, isolated from all other logic
+	sig := func(input string) crypto.Signature { // hexStr -> signature
+		b := hbs(input)
+		hash := crypto.HashBytes(b)
+		return crypto.SignHash(hash, sk)
+	}
+
+	// transaction containing all possible fields,
+	// as well as all valid unlock hashes and input locks.
+	txn := Transaction{
+		Version: 1,
+		CoinInputs: []CoinInput{
+			{
+				ParentID: CoinOutputID(hs("a3331dc5ad8fef504e148e1608db0f05156dc72283dc2b1b083afa8bfdcdb6d9")),
+				Fulfillment: UnlockFulfillmentProxy{
+					Fulfillment: NewSingleSignatureFulfillment(pk),
+				},
+			},
+			{
+				ParentID: CoinOutputID(hs("fd166ead847ae80a5754700980130ee7bd23a94bd2a8fa14807955142719eb05")),
+				Fulfillment: UnlockFulfillmentProxy{
+					Fulfillment: NewAtomicSwapClaimFulfillment(pk, secret),
+				},
+			},
+		},
+		CoinOutputs: []CoinOutput{
+			{
+				Value:     NewCurrency64(42000000000),
+				Condition: UnlockConditionProxy{}, // nil condition
+			},
+			{
+				Value: NewCurrency64(684465979878000000),
+				Condition: UnlockConditionProxy{
+					Condition: NewUnlockHashCondition(unlockHashFromHex("0118bc060e820e8ae35bafae2a3b85e600caa9cb2e50cfd46a2d98253d7d7780c940ea682e7b40")),
+				},
+			},
+			{
+				Value: NewCurrency64(50000000000000),
+				Condition: UnlockConditionProxy{
+					Condition: &AtomicSwapCondition{
+						Sender:       unlockHashFromHex("01fea3ae2854f6e497c92a1cdd603a0bc92ada717200e74f64731e86a923479883519804b18d9d"),
+						Receiver:     unlockHashFromHex("01746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9aa9e7c6f58893"),
+						HashedSecret: hashedSecret,
+						TimeLock:     2524608000,
+					},
+				},
+			},
+			{
+				Value: NewCurrency64(42000000000),
+				Condition: UnlockConditionProxy{
+					Condition: &TimeLockCondition{
+						LockTime:  2524608000,
+						Condition: NewUnlockHashCondition(unlockHashFromHex("0118bc060e820e8ae35bafae2a3b85e600caa9cb2e50cfd46a2d98253d7d7780c940ea682e7b40")),
+					},
+				},
+			},
+		},
+		BlockStakeInputs: []BlockStakeInput{
+			{
+				ParentID: BlockStakeOutputID(hs("dca04a18b64ba012218d28d265a852625416567932f5eda3bcb0a0bc66da8b09")),
+				Fulfillment: UnlockFulfillmentProxy{
+					Fulfillment: NewSingleSignatureFulfillment(pk),
+				},
+			},
+		},
+		BlockStakeOutputs: []BlockStakeOutput{
+			{
+				Value: NewCurrency64(390),
+				Condition: UnlockConditionProxy{
+					Condition: NewUnlockHashCondition(unlockHashFromHex("01746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9aa9e7c6f58893")),
+				},
+			},
+		},
+		MinerFees: []Currency{
+			NewCurrency64(100000000),
+		},
+		ArbitraryData: []byte("All Creatures Great and Small Will Get Stuck at Brexit’s Border, 08/05/2018 06:00 CEST"),
+	}
+
+	var (
+		signature         ByteSlice
+		expectedSignature crypto.Signature
+	)
+
+	// BlockStake Fulfillment, input #0: SingleSignature
+	err = txn.BlockStakeInputs[0].Fulfillment.Sign(FulfillmentSignContext{
+		InputIndex:  0,
+		Transaction: txn,
+		Key:         sk,
+	})
+	if err != nil {
+		t.Error(err)
+	}
+	// decode expected signature
+	expectedSignature = sig(
+		`01` + // transaction version
+			`0000000000000000` + // input index
+			`0200000000000000` + // length(coinInputs), 2
+			`a3331dc5ad8fef504e148e1608db0f05156dc72283dc2b1b083afa8bfdcdb6d9` + // CI#1 - parentid only
+			`fd166ead847ae80a5754700980130ee7bd23a94bd2a8fa14807955142719eb05` + // CI#2 - parentid only
+			`0400000000000000` + // length(coinOutputs), 4
+			`050000000000000009c7652400` + // CO#1
+			`00` + `0000000000000000` +
+			`0800000000000000097fb62ea777c580` + // CO#2
+			`01` + `2100000000000000` + `0118bc060e820e8ae35bafae2a3b85e600caa9cb2e50cfd46a2d98253d7d7780c9` +
+			`06000000000000002d79883d2000` + // CO#3
+			`02` + `6a00000000000000` + `01fea3ae2854f6e497c92a1cdd603a0bc92ada717200e74f64731e86a923479883` + `01746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9a` + sliceToHex(hashedSecret[:]) + `00767a9600000000` +
+			`050000000000000009c7652400` + // CO#4
+			`03` + `2a00000000000000` + `00767a9600000000` + `01` + `0118bc060e820e8ae35bafae2a3b85e600caa9cb2e50cfd46a2d98253d7d7780c9` +
+			`0100000000000000` + // length(blockStakeInputs), 1
+			`dca04a18b64ba012218d28d265a852625416567932f5eda3bcb0a0bc66da8b09` + // BSI#1
+			`0100000000000000` + // length(blockStakeOutputs), 1
+			`02000000000000000186` + // BSO#1
+			`01` + `2100000000000000` +
+			`01746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9a` +
+			`0100000000000000` + // length(minerFees), 1
+			`040000000000000005f5e100` + // MF#1
+			`5800000000000000` + // length(arbitraryData)
+			`416c6c2043726561747572657320477265617420616e6420536d616c6c2057696c6c2047657420537475636b20617420427265786974e280997320426f726465722c2030382f30352f323031382030363a30302043455354`, // arbitraryData
+	)
+	signature = txn.BlockStakeInputs[0].Fulfillment.Fulfillment.(*SingleSignatureFulfillment).Signature
+	if bytes.Compare(expectedSignature[:], signature[:]) != 0 {
+		t.Error("blockStake input #0: ",
+			hex.EncodeToString(expectedSignature[:]), "!=",
+			hex.EncodeToString(signature[:]))
+	}
+
+	// Coin Fulfillment, input #0: SingleSignature
+	err = txn.CoinInputs[0].Fulfillment.Sign(FulfillmentSignContext{
+		InputIndex:  0,
+		Transaction: txn,
+		Key:         sk,
+	})
+
+	if err != nil {
+		t.Error(err)
+	}
+	signature = txn.CoinInputs[0].Fulfillment.Fulfillment.(*SingleSignatureFulfillment).Signature
+	// signature is same as previous signature, so we can compare directly
+	if bytes.Compare(expectedSignature[:], signature[:]) != 0 {
+		t.Error("coin input #0: ",
+			hex.EncodeToString(expectedSignature[:]), "!=",
+			hex.EncodeToString(signature[:]))
+	}
+
+	// Coin Fulfillment, input #1: AtomicSwapFulfillment
+	err = txn.CoinInputs[1].Fulfillment.Sign(FulfillmentSignContext{
+		InputIndex:  1,
+		Transaction: txn,
+		Key:         sk,
+	})
+	if err != nil {
+		t.Error(err)
+	}
+	signature = txn.CoinInputs[1].Fulfillment.Fulfillment.(*AtomicSwapFulfillment).Signature
+	// decode expected signature
+	expectedSignature = sig(
+		`01` + // transaction version
+			`0100000000000000` + // input index
+			sliceToHex(encoding.Marshal(pk)) + // AS: PublicKey
+			sliceToHex(secret[:]) + // AS: Claim: secret
+			`0200000000000000` + // length(coinInputs), 2
+			`a3331dc5ad8fef504e148e1608db0f05156dc72283dc2b1b083afa8bfdcdb6d9` + // CI#1 - parentid only
+			`fd166ead847ae80a5754700980130ee7bd23a94bd2a8fa14807955142719eb05` + // CI#2 - parentid only
+			`0400000000000000` + // length(coinOutputs), 4
+			`050000000000000009c7652400` + // CO#1
+			`00` + `0000000000000000` +
+			`0800000000000000097fb62ea777c580` + // CO#2
+			`01` + `2100000000000000` + `0118bc060e820e8ae35bafae2a3b85e600caa9cb2e50cfd46a2d98253d7d7780c9` +
+			`06000000000000002d79883d2000` + // CO#3
+			`02` + `6a00000000000000` + `01fea3ae2854f6e497c92a1cdd603a0bc92ada717200e74f64731e86a923479883` + `01746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9a` + sliceToHex(hashedSecret[:]) + `00767a9600000000` +
+			`050000000000000009c7652400` + // CO#4
+			`03` + `2a00000000000000` + `00767a9600000000` + `01` + `0118bc060e820e8ae35bafae2a3b85e600caa9cb2e50cfd46a2d98253d7d7780c9` +
+			`0100000000000000` + // length(blockStakeInputs), 1
+			`dca04a18b64ba012218d28d265a852625416567932f5eda3bcb0a0bc66da8b09` + // BSI#1
+			`0100000000000000` + // length(blockStakeOutputs), 1
+			`02000000000000000186` + // BSO#1
+			`01` + `2100000000000000` +
+			`01746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9a` +
+			`0100000000000000` + // length(minerFees), 1
+			`040000000000000005f5e100` + // MF#1
+			`5800000000000000` + // length(arbitraryData)
+			`416c6c2043726561747572657320477265617420616e6420536d616c6c2057696c6c2047657420537475636b20617420427265786974e280997320426f726465722c2030382f30352f323031382030363a30302043455354`, // arbitraryData
+	)
+	if bytes.Compare(expectedSignature[:], signature[:]) != 0 {
+		t.Error("coin input #1: ",
+			hex.EncodeToString(expectedSignature[:]), "!=",
+			hex.EncodeToString(signature[:]))
+	}
+}
+
+// TestLegacyInputSigHash tests the legacy input signature hash algorithm.
+// It is the algorithm used to compute a signature for an input within a v0 transaction.
+//
+// Pseudo code of signature algorithm, as documented:
+//
+//    blake2b_256_hash(BinaryEncoding(
+//      - inputIndex: int64 (8 bytes, little endian),
+//      extraObjects:
+//        if atomicSwap:
+//          SiaPublicKey:
+//            - Algorithm: 16 bytes fixed-size array
+//            - Key: 8 bytes length + n bytes
+//        if atomicSwap as claimer (owner of receiver pub key):
+//          - Secret: 32 bytes fixed-size array
+//      for each coinInput:
+//        - parentID: 32 bytes fixed-size array
+//        - unlockHash: 33 bytes fixed-size array
+//      - length(coinOutputs): int64 (8 bytes, little endian)
+//      for each coinOutput:
+//        - value: Currency (8 bytes length + n bytes, little endian encoded)
+//        - unlockHash: 33 bytes fixed-size array
+//      for each blockStakeInput:
+//        - parentID: 32 bytes fixed-size array
+//        - unlockHash: 33 bytes fixed-size array
+//      - length(blockStakeOutputs): int64 (8 bytes, little endian)
+//      for each blockStakeOutput:
+//        - value: Currency (8 bytes length + n bytes, little endian encoded)
+//        - unlockHash: 33 bytes fixed-size array
+//      - length(minerFees): int64 (8 bytes, little endian)
+//      for each minerFee:
+//        - fee: Currency (8 bytes length + n bytes, little endian encoded)
+//      - arbitraryData: 8 bytes length + n bytes
+//    )) : 32 bytes fixed-size crypto hash
+//
+// BinaryEncoding encodes all bytes as described above,
+// concatenating all output bytes together, in order as given.
+// The total output byte slice (result of encoding and concatenation)
+// is used as the input to make the crypto hashsum using the blake2b 256bit algorithm,
+// resulting in a 32 bytes fixed-size crypto hash.
+//
+// See /doc/Encoding.md for more information
+// about the Binary Encoding Algorithm and how each (primitive) type is encoded.
+//
+// ENSURE TO KEEP THIS TEST UP TO DATE WITH BOTH THE IMPLEMENTATION
+// AS WELL AS THE EXTERNAL (/doc/**/*) DOCUMENTATION !!
+func TestLegacyInputSigHash(t *testing.T) {
+	// utility funcs
+	hbs := func(str string) []byte { // hexStr -> byte slice
+		bs, err := hex.DecodeString(str)
+		if err != nil {
+			t.Error(err)
+		}
+		return bs
+	}
+	hs := func(str string) (hash crypto.Hash) { // hbs -> crypto.Hash
+		copy(hash[:], hbs(str))
+		return
+	}
+	sliceToHex := func(b []byte) string {
+		return hex.EncodeToString(b[:])
+	}
+	hashToHex := func(hash crypto.Hash) string {
+		return sliceToHex(hash[:])
+	}
+
+	// deterministic private/public key pair
+	var entropy [crypto.EntropySize]byte
+	b, err := hex.DecodeString("5722127ae85b120d15d5998d7591a603f4cbe2ac47a69b4d16bd7c90e21aeedd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	copy(entropy[:], b[:])
+	sk, rpk := crypto.GenerateKeyPairDeterministic(entropy)
+	pk := Ed25519PublicKey(rpk)
+
+	// deterministic atomic swap secret
+	var secret AtomicSwapSecret
+	b, err = hex.DecodeString("8a1ed1737c0a84598bbf429ba351e03b5f4e00d7ab5d8635da832957f14bb272")
+	if err != nil {
+		t.Fatal(err)
+	}
+	copy(secret[:], b[:])
+	hashedSecret := NewAtomicSwapHashedSecret(secret)
+
+	// signature computation algo, isolated from all other logic
+	sig := func(input string) crypto.Signature { // hexStr -> signature
+		b := hbs(input)
+		hash := crypto.HashBytes(b)
+		return crypto.SignHash(hash, sk)
+	}
+
+	// transaction containing all possible fields,
+	// as well as all valid unlock hashes and input locks.
+	txn := Transaction{
+		Version: 0,
+		CoinInputs: []CoinInput{
+			{
+				ParentID: CoinOutputID(hs("a3331dc5ad8fef504e148e1608db0f05156dc72283dc2b1b083afa8bfdcdb6d9")),
+				Fulfillment: UnlockFulfillmentProxy{
+					Fulfillment: NewSingleSignatureFulfillment(pk),
+				},
+			},
+			{
+				ParentID: CoinOutputID(hs("fd166ead847ae80a5754700980130ee7bd23a94bd2a8fa14807955142719eb05")),
+				Fulfillment: UnlockFulfillmentProxy{
+					Fulfillment: &LegacyAtomicSwapFulfillment{
+						Sender:       unlockHashFromHex("01fea3ae2854f6e497c92a1cdd603a0bc92ada717200e74f64731e86a923479883519804b18d9d"),
+						Receiver:     NewPubKeyUnlockHash(pk),
+						HashedSecret: hashedSecret,
+						TimeLock:     2524608000,
+						PublicKey:    pk,
+						Secret:       secret,
+					},
+				},
+			},
+		},
+		CoinOutputs: []CoinOutput{
+			{
+				Value: NewCurrency64(684465979878000000),
+				Condition: UnlockConditionProxy{
+					Condition: NewUnlockHashCondition(unlockHashFromHex("0118bc060e820e8ae35bafae2a3b85e600caa9cb2e50cfd46a2d98253d7d7780c940ea682e7b40")),
+				},
+			},
+			{
+				Value: NewCurrency64(50000000000000),
+				Condition: UnlockConditionProxy{
+					Condition: NewUnlockHashCondition(unlockHashFromHex("0296551728f6e1a244184dcad09b4e76debf16bd4721acd87b073404eb74d151aefff6ce6b7a86")),
+				},
+			},
+		},
+		BlockStakeInputs: []BlockStakeInput{
+			{
+				ParentID: BlockStakeOutputID(hs("dca04a18b64ba012218d28d265a852625416567932f5eda3bcb0a0bc66da8b09")),
+				Fulfillment: UnlockFulfillmentProxy{
+					Fulfillment: NewSingleSignatureFulfillment(pk),
+				},
+			},
+		},
+		BlockStakeOutputs: []BlockStakeOutput{
+			{
+				Value: NewCurrency64(390),
+				Condition: UnlockConditionProxy{
+					Condition: NewUnlockHashCondition(unlockHashFromHex("01746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9aa9e7c6f58893")),
+				},
+			},
+		},
+		MinerFees: []Currency{
+			NewCurrency64(100000000),
+		},
+		ArbitraryData: []byte("Nestle Pays $7.2 Billion to Sell Coffee With Starbucks Brand, 07/05/2018 07:13 CEST"),
+	}
+
+	var (
+		signature         ByteSlice
+		expectedSignature crypto.Signature
+	)
+
+	// BlockStake Fulfillment, input #0: SingleSignature
+	err = txn.BlockStakeInputs[0].Fulfillment.Sign(FulfillmentSignContext{
+		InputIndex:  0,
+		Transaction: txn,
+		Key:         sk,
+	})
+	if err != nil {
+		t.Error(err)
+	}
+	// decode expected signature
+	expectedSignature = sig(
+		`0000000000000000` + // input index
+			`a3331dc5ad8fef504e148e1608db0f05156dc72283dc2b1b083afa8bfdcdb6d9` + // CI#1
+			`01` + hashToHex(crypto.HashObject(encoding.Marshal(pk))) +
+			`fd166ead847ae80a5754700980130ee7bd23a94bd2a8fa14807955142719eb05` + // CI#2
+			`02` + hashToHex(crypto.HashObject(encoding.MarshalAll(
+			unlockHashFromHex("01fea3ae2854f6e497c92a1cdd603a0bc92ada717200e74f64731e86a923479883519804b18d9d"),
+			NewPubKeyUnlockHash(pk),
+			hashedSecret,
+			Timestamp(2524608000),
+		))) +
+			`0200000000000000` + // length(coinOutputs), 2
+			`0800000000000000097fb62ea777c580` + // CO#1
+			`0118bc060e820e8ae35bafae2a3b85e600caa9cb2e50cfd46a2d98253d7d7780c9` +
+			`06000000000000002d79883d2000` + // CO#2
+			`0296551728f6e1a244184dcad09b4e76debf16bd4721acd87b073404eb74d151ae` +
+			`dca04a18b64ba012218d28d265a852625416567932f5eda3bcb0a0bc66da8b09` + // BSI#1
+			`01` + hashToHex(crypto.HashObject(encoding.Marshal(pk))) +
+			`0100000000000000` + // length(blockStakeOutputs), 1
+			`02000000000000000186` + // BSO#1
+			`01746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9a` +
+			`0100000000000000` + // length(minerFees), 1
+			`040000000000000005f5e100` + // MF#1
+			`5300000000000000` + // length(arbitraryData)
+			`4e6573746c6520506179732024372e322042696c6c696f6e20746f2053656c6c20436f66666565205769746820537461726275636b73204272616e642c2030372f30352f323031382030373a31332043455354`, // arbitraryData
+	)
+	signature = txn.BlockStakeInputs[0].Fulfillment.Fulfillment.(*SingleSignatureFulfillment).Signature
+	if bytes.Compare(expectedSignature[:], signature[:]) != 0 {
+		t.Error("blockStake input #0: ",
+			hex.EncodeToString(expectedSignature[:]), "!=",
+			hex.EncodeToString(signature[:]))
+	}
+
+	// Coin Fulfillment, input #0: SingleSignature
+	err = txn.CoinInputs[0].Fulfillment.Sign(FulfillmentSignContext{
+		InputIndex:  0,
+		Transaction: txn,
+		Key:         sk,
+	})
+
+	if err != nil {
+		t.Error(err)
+	}
+	signature = txn.CoinInputs[0].Fulfillment.Fulfillment.(*SingleSignatureFulfillment).Signature
+	// signature is same as previous signature, so we can compare directly
+	if bytes.Compare(expectedSignature[:], signature[:]) != 0 {
+		t.Error("coin input #0: ",
+			hex.EncodeToString(expectedSignature[:]), "!=",
+			hex.EncodeToString(signature[:]))
+	}
+
+	// Coin Fulfillment, input #1: SingleSignature
+	err = txn.CoinInputs[1].Fulfillment.Sign(FulfillmentSignContext{
+		InputIndex:  1,
+		Transaction: txn,
+		Key:         sk,
+	})
+	if err != nil {
+		t.Error(err)
+	}
+	signature = txn.CoinInputs[1].Fulfillment.Fulfillment.(*LegacyAtomicSwapFulfillment).Signature
+	// decode expected signature
+	expectedSignature = sig(
+		`0100000000000000` + // input index
+			sliceToHex(encoding.Marshal(pk)) + // AS: PublicKey
+			sliceToHex(secret[:]) + // AS: Claim: secret
+			`a3331dc5ad8fef504e148e1608db0f05156dc72283dc2b1b083afa8bfdcdb6d9` + // CI#1
+			`01` + hashToHex(crypto.HashObject(encoding.Marshal(pk))) +
+			`fd166ead847ae80a5754700980130ee7bd23a94bd2a8fa14807955142719eb05` + // CI#2
+			`02` + hashToHex(crypto.HashObject(encoding.MarshalAll(
+			unlockHashFromHex("01fea3ae2854f6e497c92a1cdd603a0bc92ada717200e74f64731e86a923479883519804b18d9d"),
+			NewPubKeyUnlockHash(pk),
+			hashedSecret,
+			Timestamp(2524608000),
+		))) +
+			`0200000000000000` + // length(coinOutputs), 2
+			`0800000000000000097fb62ea777c580` + // CO#1
+			`0118bc060e820e8ae35bafae2a3b85e600caa9cb2e50cfd46a2d98253d7d7780c9` +
+			`06000000000000002d79883d2000` + // CO#2
+			`0296551728f6e1a244184dcad09b4e76debf16bd4721acd87b073404eb74d151ae` +
+			`dca04a18b64ba012218d28d265a852625416567932f5eda3bcb0a0bc66da8b09` + // BSI#1
+			`01` + hashToHex(crypto.HashObject(encoding.Marshal(pk))) +
+			`0100000000000000` + // length(blockStakeOutputs), 1
+			`02000000000000000186` + // BSO#1
+			`01746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9a` +
+			`0100000000000000` + // length(minerFees), 1
+			`040000000000000005f5e100` + // MF#1
+			`5300000000000000` + // length(arbitraryData)
+			`4e6573746c6520506179732024372e322042696c6c696f6e20746f2053656c6c20436f66666565205769746820537461726275636b73204272616e642c2030372f30352f323031382030373a31332043455354`, // arbitraryData
+	)
+	if bytes.Compare(expectedSignature[:], signature[:]) != 0 {
+		t.Error("coin input #1: ",
+			hex.EncodeToString(expectedSignature[:]), "!=",
+			hex.EncodeToString(signature[:]))
+	}
+}


### PR DESCRIPTION
+ add light_wallet.md: used as a guide for anyone wishing to
   implement their own light wallet/client
+ documents timelock conditions (fixes #297)
+ documents and explains v1 transactions, explains it deprecates
    v0 transactions, and updates any outdated information (fixes #296)
+ add unit tests to ensure our signture psuedocode is correct (closes #315)