### PR TITLE
support raw (JSON) conditions in the wallet send commands

### DIFF
--- a/api/wallet.go
+++ b/api/wallet.go
@@ -81,8 +81,7 @@ type (
 	// WalletCoinsPOST is given by the user
 	// to indicate to where to send how much coins
 	WalletCoinsPOST struct {
-		CoinOutputs        []types.CoinOutput       `json:"coinoutputs`
-		TransactionVersion types.TransactionVersion `json:"version"`
+		CoinOutputs []types.CoinOutput `json:"coinoutputs`
 	}
 	// WalletCoinsPOSTResp Resp contains the ID of the transaction
 	// that was created as a result of a POST call to /wallet/coins.
@@ -93,8 +92,7 @@ type (
 	// WalletBlockStakesPOST is given by the user
 	// to indicate to where to send how much blockstakes
 	WalletBlockStakesPOST struct {
-		BlockStakeOutputs  []types.BlockStakeOutput `json:"blockstakeoutputs`
-		TransactionVersion types.TransactionVersion `json:"version"`
+		BlockStakeOutputs []types.BlockStakeOutput `json:"blockstakeoutputs`
 	}
 	// WalletBlockStakesPOSTResp Resp contains the ID of the transaction
 	// that was created as a result of a POST call to /wallet/blockstakes.
@@ -397,7 +395,7 @@ func (api *API) walletCoinsHandler(w http.ResponseWriter, req *http.Request, _ h
 		WriteError(w, Error{"error decoding the supplied coin outputs: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
-	tx, err := api.wallet.SendOutputs(body.CoinOutputs, nil, nil, body.TransactionVersion)
+	tx, err := api.wallet.SendOutputs(body.CoinOutputs, nil, nil)
 	if err != nil {
 		WriteError(w, Error{"error after call to /wallet/coins: " + err.Error()}, http.StatusInternalServerError)
 		return
@@ -414,7 +412,7 @@ func (api *API) walletBlockStakesHandler(w http.ResponseWriter, req *http.Reques
 		WriteError(w, Error{"error decoding the supplied blockstake outputs: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
-	tx, err := api.wallet.SendOutputs(nil, body.BlockStakeOutputs, nil, body.TransactionVersion)
+	tx, err := api.wallet.SendOutputs(nil, body.BlockStakeOutputs, nil)
 	if err != nil {
 		WriteError(w, Error{"error after call to /wallet/blockstakes: " + err.Error()}, http.StatusInternalServerError)
 		return

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -348,7 +348,7 @@ type (
 
 		// SendOutputs is a tool for sending coins and/or block stakes from the wallet, to one or multiple addreses.
 		// The transaction is automatically given to the transaction pool, and is also returned to the caller.
-		SendOutputs(coinOutputs []types.CoinOutput, blockstakeOutputs []types.BlockStakeOutput, data []byte, version types.TransactionVersion) (types.Transaction, error)
+		SendOutputs(coinOutputs []types.CoinOutput, blockstakeOutputs []types.BlockStakeOutput, data []byte) (types.Transaction, error)
 
 		// BlockStakeStats returns the blockstake statistical information of
 		// this wallet of the last 1000 blocks. If the blockcount is less than

--- a/modules/wallet/money.go
+++ b/modules/wallet/money.go
@@ -116,7 +116,7 @@ func (w *Wallet) SendCoins(amount types.Currency, cond types.UnlockConditionProx
 			Condition: cond,
 			Value:     amount,
 		},
-	}, nil, data, w.chainCts.DefaultTransactionVersion)
+	}, nil, nil)
 }
 
 // SendBlockStakes creates a transaction sending 'amount' to whoever can fulfill the condition. The transaction
@@ -127,12 +127,12 @@ func (w *Wallet) SendBlockStakes(amount types.Currency, cond types.UnlockConditi
 			Condition: cond,
 			Value:     amount,
 		},
-	}, nil, w.chainCts.DefaultTransactionVersion)
+	}, nil)
 }
 
 // SendOutputs is a tool for sending coins and block stakes from the wallet, to one or multiple addreses.
 // The transaction is automatically given to the transaction pool, and is also returned to the caller.
-func (w *Wallet) SendOutputs(coinOutputs []types.CoinOutput, blockstakeOutputs []types.BlockStakeOutput, data []byte, version types.TransactionVersion) (types.Transaction, error) {
+func (w *Wallet) SendOutputs(coinOutputs []types.CoinOutput, blockstakeOutputs []types.BlockStakeOutput, data []byte) (types.Transaction, error) {
 	if len(coinOutputs) == 0 && len(blockstakeOutputs) == 0 {
 		// at least one coin output OR one block stake output has to be send
 		return types.Transaction{}, ErrNilOutputs
@@ -145,7 +145,7 @@ func (w *Wallet) SendOutputs(coinOutputs []types.CoinOutput, blockstakeOutputs [
 
 	tpoolFee := w.chainCts.MinimumTransactionFee.Mul64(1) // TODO better fee algo
 	totalAmount := types.NewCurrency64(0).Add(tpoolFee)
-	txnBuilder := w.StartTransactionWithVersion(version)
+	txnBuilder := w.StartTransaction()
 	for _, co := range coinOutputs {
 		txnBuilder.AddCoinOutput(co)
 		totalAmount = totalAmount.Add(co.Value)

--- a/modules/wallet/money_test.go
+++ b/modules/wallet/money_test.go
@@ -209,7 +209,7 @@ func TestNilOutputs(t *testing.T) {
 	}
 	defer wt.closeWt()
 
-	_, err = wt.wallet.SendOutputs(nil, nil, []byte("data"), types.TransactionVersionOne)
+	_, err = wt.wallet.SendOutputs(nil, nil, []byte("data"))
 	if err != ErrNilOutputs {
 		t.Fatal("expected ErrNilOutput, but receiver: ", err)
 	}

--- a/pkg/client/walletcmd_test.go
+++ b/pkg/client/walletcmd_test.go
@@ -1,0 +1,195 @@
+package client
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/rivine/rivine/crypto"
+	"github.com/rivine/rivine/types"
+)
+
+func TestParsePairedOutputs(t *testing.T) {
+	// utility funcs
+	hbs := func(str string) []byte { // hexStr -> byte slice
+		bs, err := hex.DecodeString(str)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return bs
+	}
+	hs := func(str string) (hash crypto.Hash) { // hbs -> crypto.Hash
+		copy(hash[:], hbs(str))
+		return
+	}
+
+	testCases := []struct {
+		Arguments     []string
+		ExpectedPairs []outputPair
+	}{
+		{nil, nil}, // error, not enough
+		{[]string{"01746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9aa9e7c6f58893"}, nil}, // error not enough
+		{
+			[]string{"01746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9aa9e7c6f58893", "42"},
+			[]outputPair{outputPair{
+				Value: types.NewCurrency64(42000000000),
+				Condition: types.NewCondition(types.NewUnlockHashCondition(types.UnlockHash{
+					Type: types.UnlockTypePubKey,
+					Hash: hs("746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9a"),
+				})),
+			}},
+		}, // no error
+		{
+			[]string{"01746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9aa9e7c6f58893", "zz"},
+			nil,
+		}, // error, invalid (currency) value
+		{
+			[]string{
+				"01746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9aa9e7c6f58893", "42",
+				"01ad4f73417476f8b8350298681dd0fa8640baa53a91915417b1dd8103d118b543c992e6fba1c4",
+			},
+			nil,
+		}, // error, arguments length needs to be even (paired)
+		{
+			[]string{
+				"01746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9aa9e7c6f58893", "42",
+				"01ad4f73417476f8b8350298681dd0fa8640baa53a91915417b1dd8103d118b543c992e6fba1c4", "10000",
+			},
+			[]outputPair{
+				outputPair{
+					Value: types.NewCurrency64(42000000000),
+					Condition: types.NewCondition(types.NewUnlockHashCondition(types.UnlockHash{
+						Type: types.UnlockTypePubKey,
+						Hash: hs("746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9a"),
+					})),
+				},
+				outputPair{
+					Value: types.NewCurrency64(10000000000000),
+					Condition: types.NewCondition(types.NewUnlockHashCondition(types.UnlockHash{
+						Type: types.UnlockTypePubKey,
+						Hash: hs("ad4f73417476f8b8350298681dd0fa8640baa53a91915417b1dd8103d118b543"),
+					})),
+				},
+			},
+		}, // no error
+		{
+			[]string{`{"type":1,"data":{"unlockhash":"01746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9aa9e7c6f58893"}}`, "4.2"},
+			[]outputPair{outputPair{
+				Value: types.NewCurrency64(4200000000),
+				Condition: types.NewCondition(types.NewUnlockHashCondition(types.UnlockHash{
+					Type: types.UnlockTypePubKey,
+					Hash: hs("746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9a"),
+				})),
+			}},
+		}, // no error, more explicit version of first non-error example
+		{
+			[]string{`{"type":3,"data":{"locktime":42,"condition":{"type":1,"data":{"unlockhash":"01746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9aa9e7c6f58893"}}}}`, "42"},
+			[]outputPair{outputPair{
+				Value: types.NewCurrency64(42000000000),
+				Condition: types.NewCondition(types.NewTimeLockCondition(42, types.NewUnlockHashCondition(types.UnlockHash{
+					Type: types.UnlockTypePubKey,
+					Hash: hs("746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9a"),
+				}))),
+			}},
+		}, // no error, more explicit version of first non-error example, combined with a timelock
+		{
+			[]string{
+				`01ad4f73417476f8b8350298681dd0fa8640baa53a91915417b1dd8103d118b543c992e6fba1c4`, "1000",
+				`{"type":3,"data":{"locktime":42,"condition":{"type":1,"data":{"unlockhash":"01746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9aa9e7c6f58893"}}}}`, "90000.50",
+				`01746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9aa9e7c6f58893`, "200",
+				`{
+					"type": 4,
+					"data": {
+						"unlockhashes": [
+							"01746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9aa9e7c6f58893",
+							"01ad4f73417476f8b8350298681dd0fa8640baa53a91915417b1dd8103d118b543c992e6fba1c4"
+						],
+						"minimumsignaturecount": 1
+					}
+				}`, "12.345",
+				`{}`, "100",
+			},
+			[]outputPair{
+				outputPair{
+					Value: types.NewCurrency64(1000000000000),
+					Condition: types.NewCondition(types.NewUnlockHashCondition(types.UnlockHash{
+						Type: types.UnlockTypePubKey,
+						Hash: hs("ad4f73417476f8b8350298681dd0fa8640baa53a91915417b1dd8103d118b543"),
+					})),
+				},
+				outputPair{
+					Value: types.NewCurrency64(90000500000000),
+					Condition: types.NewCondition(types.NewTimeLockCondition(42, types.NewUnlockHashCondition(types.UnlockHash{
+						Type: types.UnlockTypePubKey,
+						Hash: hs("746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9a"),
+					}))),
+				},
+				outputPair{
+					Value: types.NewCurrency64(200000000000),
+					Condition: types.NewCondition(types.NewUnlockHashCondition(types.UnlockHash{
+						Type: types.UnlockTypePubKey,
+						Hash: hs("746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9a"),
+					})),
+				},
+				outputPair{
+					Value: types.NewCurrency64(12345000000),
+					Condition: types.NewCondition(types.NewMultiSignatureCondition(types.UnlockHashSlice{
+						types.UnlockHash{
+							Type: types.UnlockTypePubKey,
+							Hash: hs("746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9a"),
+						},
+						types.UnlockHash{
+							Type: types.UnlockTypePubKey,
+							Hash: hs("ad4f73417476f8b8350298681dd0fa8640baa53a91915417b1dd8103d118b543"),
+						},
+					}, 1)),
+				},
+				outputPair{
+					Value:     types.NewCurrency64(100000000000),
+					Condition: types.NewCondition(&types.NilCondition{}),
+				},
+			},
+		}, // no error, a more complex example
+	}
+	for idx, testCase := range testCases {
+		pairs, err := parsePairedOutputs(testCase.Arguments)
+		if len(testCase.ExpectedPairs) == 0 {
+			// expecting error
+			if err == nil {
+				t.Error("expected error, but received none for idx: ", idx)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("received unexpected error for idx %d: %v", idx, err)
+		}
+		for i, pair := range pairs {
+			if !pair.Value.Equals(testCase.ExpectedPairs[i].Value) {
+				t.Errorf("unexpected pair (currency) value for pair %d/#%d: '%v' != '%v'",
+					idx, i, testCase.ExpectedPairs[i].Value, pair.Value)
+			}
+			bsA, err := pair.Condition.MarshalJSON()
+			if err != nil {
+				t.Errorf("failed to JSON encode output pair %d/#%d's condition: %v", idx, i, err)
+			}
+			bsB, err := testCase.ExpectedPairs[i].Condition.MarshalJSON()
+			if err != nil {
+				t.Errorf("failed to JSON encode expected pair %d/#%d's condition: %v", idx, i, err)
+			}
+			if bytes.Compare(bsA, bsB) != 0 {
+				t.Errorf("unexpected pair (currency) value for pair %d/#%d: '%s' != '%s'",
+					idx, i, string(bsA), string(bsB))
+			}
+		}
+	}
+}
+
+func init() {
+	if _CurrencyConvertor == (CurrencyConvertor{}) {
+		var err error
+		_CurrencyConvertor, err = NewCurrencyConvertor(types.DefaultCurrencyUnits())
+		if err != nil {
+			panic(err)
+		}
+	}
+}


### PR DESCRIPTION
closes #323

also removes the --legacy and --locktime flags,
sending legacy transactions has no value so no longer needed,
and --locktime is no longer needed as you can use this feature now
by sending a raw JSON-encoded condition