### PR TITLE
make multisig condition/fulfillment standard checking stricter

### DIFF
--- a/types/unlockcondition.go
+++ b/types/unlockcondition.go
@@ -1525,6 +1525,11 @@ func (ms *MultiSignatureCondition) IsStandardCondition() error {
 	if ms.MinimumSignatureCount > uint64(len(ms.UnlockHashes)) {
 		return errors.New("The minimum amount of signatures can't be higher than the amount of unlockhashes")
 	}
+	for idx, uh := range ms.UnlockHashes {
+		if uh.Type != UnlockTypePubKey {
+			return fmt.Errorf("unsupported unlock hash #%d type: %d", idx, uh.Type)
+		}
+	}
 	return nil
 }
 

--- a/types/unlockcondition.go
+++ b/types/unlockcondition.go
@@ -1519,8 +1519,8 @@ func (ms *MultiSignatureCondition) IsStandardCondition() error {
 	if ms.MinimumSignatureCount == 0 {
 		return errors.New("A minimum amount of required signatures must be specified")
 	}
-	if len(ms.UnlockHashes) == 0 {
-		return errors.New("At least a single unlockhash must be provided which identifies a possible signatory")
+	if len(ms.UnlockHashes) < 2 {
+		return errors.New("At least two unlockhashes must be provided which identifies to possible signatories")
 	}
 	if ms.MinimumSignatureCount > uint64(len(ms.UnlockHashes)) {
 		return errors.New("The minimum amount of signatures can't be higher than the amount of unlockhashes")
@@ -1608,6 +1608,9 @@ func (ms *MultiSignatureFulfillment) FulfillmentType() FulfillmentType {
 
 // IsStandardFulfillment implements UnlockFulfillment.IsStandardFulfillment
 func (ms *MultiSignatureFulfillment) IsStandardFulfillment() error {
+	if len(ms.Pairs) == 0 {
+		return errors.New("At least one pair must be provided")
+	}
 	var err error
 	for _, pair := range ms.Pairs {
 		err = strictSignatureCheck(pair.PublicKey, pair.Signature)

--- a/types/unlockcondition_test.go
+++ b/types/unlockcondition_test.go
@@ -2066,7 +2066,7 @@ func TestIsStandardCondition(t *testing.T) {
 					MinimumSignatureCount: 2,
 					UnlockHashes: UnlockHashSlice{
 						unlockHashFromHex("015fe50b9c596d8717e5e7ba79d5a7c9c8b82b1427a04d5c0771268197c90e99dccbcdf0ba9c90"),
-						unlockHashFromHex("02a24c97c80eeac111aa4bcbb0ac8ffc364fa9b22da10d3054778d2332f68b365e5e5af8e71541"),
+						unlockHashFromHex("01fc8714235d549f890f35e52d745b9eeeee34926f96c4b9ef1689832f338d9349b453898f7e51"),
 						unlockHashFromHex("01746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9aa9e7c6f58893"),
 					},
 				},
@@ -2079,7 +2079,7 @@ func TestIsStandardCondition(t *testing.T) {
 					MinimumSignatureCount: 2,
 					UnlockHashes: UnlockHashSlice{
 						unlockHashFromHex("015fe50b9c596d8717e5e7ba79d5a7c9c8b82b1427a04d5c0771268197c90e99dccbcdf0ba9c90"),
-						unlockHashFromHex("02a24c97c80eeac111aa4bcbb0ac8ffc364fa9b22da10d3054778d2332f68b365e5e5af8e71541"),
+						unlockHashFromHex("01fc8714235d549f890f35e52d745b9eeeee34926f96c4b9ef1689832f338d9349b453898f7e51"),
 						unlockHashFromHex("01746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9aa9e7c6f58893"),
 					},
 				},
@@ -2112,7 +2112,7 @@ func TestIsStandardCondition(t *testing.T) {
 				MinimumSignatureCount: 2,
 				UnlockHashes: UnlockHashSlice{
 					unlockHashFromHex("015fe50b9c596d8717e5e7ba79d5a7c9c8b82b1427a04d5c0771268197c90e99dccbcdf0ba9c90"),
-					unlockHashFromHex("02a24c97c80eeac111aa4bcbb0ac8ffc364fa9b22da10d3054778d2332f68b365e5e5af8e71541"),
+					unlockHashFromHex("01fc8714235d549f890f35e52d745b9eeeee34926f96c4b9ef1689832f338d9349b453898f7e51"),
 					unlockHashFromHex("01746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9aa9e7c6f58893"),
 				},
 			},
@@ -2121,9 +2121,13 @@ func TestIsStandardCondition(t *testing.T) {
 		{
 			&MultiSignatureCondition{
 				MinimumSignatureCount: 2,
-				UnlockHashes:          UnlockHashSlice{},
+				UnlockHashes: UnlockHashSlice{
+					unlockHashFromHex("015fe50b9c596d8717e5e7ba79d5a7c9c8b82b1427a04d5c0771268197c90e99dccbcdf0ba9c90"),
+					unlockHashFromHex("02a24c97c80eeac111aa4bcbb0ac8ffc364fa9b22da10d3054778d2332f68b365e5e5af8e71541"),
+					unlockHashFromHex("01746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9aa9e7c6f58893"),
+				},
 			},
-			"need at least a single unlockhash",
+			"only pubKey unlockhashes are allowed",
 		},
 	}
 	for idx, testCase := range testCases {

--- a/types/unlockcondition_test.go
+++ b/types/unlockcondition_test.go
@@ -2091,6 +2091,15 @@ func TestIsStandardCondition(t *testing.T) {
 		},
 		{
 			&MultiSignatureCondition{
+				MinimumSignatureCount: 1,
+				UnlockHashes: UnlockHashSlice{
+					unlockHashFromHex("015fe50b9c596d8717e5e7ba79d5a7c9c8b82b1427a04d5c0771268197c90e99dccbcdf0ba9c90"),
+				},
+			},
+			"at least one unlock hash is required",
+		},
+		{
+			&MultiSignatureCondition{
 				MinimumSignatureCount: 2,
 				UnlockHashes: UnlockHashSlice{
 					unlockHashFromHex("015fe50b9c596d8717e5e7ba79d5a7c9c8b82b1427a04d5c0771268197c90e99dccbcdf0ba9c90"),
@@ -2509,6 +2518,10 @@ func TestIsStandardFulfillment(t *testing.T) {
 				Secret: AtomicSwapSecret{1, 2, 3},
 			},
 			"",
+		},
+		{
+			new(MultiSignatureFulfillment),
+			"no pairs given",
 		},
 		{
 			&MultiSignatureFulfillment{


### PR DESCRIPTION
+ At least 2 unlockhashes are required in the multisigcondition, as otherwise there is no point in using the multisig condition (used to be just 1, but for that people should use just an unlockhash condition);
+ Only pubkey unlockhashes are allowed, prior to this update no unlockhash type check happened;
+ At least 1 pair is required in multisigfulfillment (OK, this was already implicitly true, due to the condition requirement, and the fact that otherwise a valid condition cannot be fulfilled, but now we have a cheap early check);