### PR TITLE
atomic swap improvements and fixes

### DIFF
--- a/api/consensus.go
+++ b/api/consensus.go
@@ -120,7 +120,7 @@ func (api *API) consensusGetUnspentCoinOutputHandler(w http.ResponseWriter, req 
 		id       = ps.ByName("id")
 	)
 
-	if len(id) != len(outputID) {
+	if len(id) != len(outputID)*2 {
 		WriteError(w, Error{errInvalidIDLength.Error()}, http.StatusBadRequest)
 		return
 	}
@@ -152,7 +152,7 @@ func (api *API) consensusGetUnspentBlockstakeOutputHandler(w http.ResponseWriter
 		id       = ps.ByName("id")
 	)
 
-	if len(id) != len(outputID) {
+	if len(id) != len(outputID)*2 {
 		WriteError(w, Error{errInvalidIDLength.Error()}, http.StatusBadRequest)
 		return
 	}

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -459,6 +459,7 @@ func (api *API) walletDataHandler(w http.ResponseWriter, req *http.Request, _ ht
 	data, err := base64.StdEncoding.DecodeString(dataString)
 	if err != nil {
 		WriteError(w, Error{"error after call to /wallet/coins: Failed to decode arbitrary data"}, http.StatusBadRequest)
+		return
 	}
 	// Since zero outputs are not allowed, just send one of the smallest unit, the minimal amount.
 	// The transaction fee should be much higher anyway

--- a/pkg/cli/flag.go
+++ b/pkg/cli/flag.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"strconv"
 	"time"
+
+	"github.com/spf13/pflag"
 )
 
 const (
@@ -65,6 +67,38 @@ func (f *LockTimeFlag) LockTime() uint64 {
 	return f.lockTime
 }
 
+type (
+	// StringLoaderFlag defines a utility type,
+	// allowing any StringLoader to be turned into a pflag-interface compatible type.
+	StringLoaderFlag struct {
+		StringLoader
+	}
+	// StringLoader defines the interface of a type (t),
+	// which can be loaded from a string,
+	// as well as being turned back into a string,
+	// such that `t.LoadString(str) == nil && t.String() == str`.
+	StringLoader interface {
+		LoadString(string) error
+		String() string
+	}
+)
+
+// Set implements pflag.Value.Set,
+// which parses the string using the StringLoader's LoadString method.
+func (s StringLoaderFlag) Set(str string) error {
+	return s.LoadString(str)
+}
+
+// Type implements pflag.Value.Type
+func (s StringLoaderFlag) Type() string {
+	return "StringLoader"
+}
+
 var computeTimeNow = func() time.Time {
 	return time.Now()
 }
+
+var (
+	_ pflag.Value = (*LockTimeFlag)(nil)
+	_ pflag.Value = StringLoaderFlag{}
+)

--- a/pkg/cli/flag_test.go
+++ b/pkg/cli/flag_test.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"testing"
 	"time"
+
+	"github.com/rivine/rivine/types"
 )
 
 // TestDateOnlyLayout tests that our custom DateOnly timestamp Layout
@@ -93,6 +95,45 @@ func TestLockTimeSetStringLoop(t *testing.T) {
 		}
 		if raw := ltf.String(); raw != testCase.Raw {
 			t.Error(idx, raw, "!=", testCase.Raw)
+		}
+	}
+}
+
+func TestStringLoaderFlag(t *testing.T) {
+	// test loader->string->loader->string
+	stringLoaders := []StringLoader{
+		&types.CoinOutputID{},
+		&types.CoinOutputID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF},
+		&types.TransactionID{},
+		&types.TransactionID{1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2},
+	}
+	for idx, stringLoader := range stringLoaders {
+		str := stringLoader.String()
+		err := stringLoader.LoadString(str)
+		if err != nil {
+			t.Errorf("error while loading string for loader #%d: %v", idx, err)
+		}
+		str2 := stringLoader.String()
+		if str != str2 {
+			t.Errorf("loader #%d isn't deterministic: %s != %s", idx, str, str2)
+		}
+	}
+
+	// test string->loader->string
+	testCases := []string{
+		"0112210f9efa5441ab705226b0628679ed190eb4588b662991747ea3809d93932c7b41cbe4b732",
+		"01450aeb140c58012cb4afb48e068f976272fefa44ffe0991a8a4350a3687558d66c8fc753c37e",
+		"01e56d03c7818179c1d21ab1fe99be91ec7fa48a21ca1b0818ad55e0b241d55067e740e11c08f5",
+	}
+	for idx, testCase := range testCases {
+		var uh types.UnlockHash
+		err := uh.LoadString(testCase)
+		if err != nil {
+			t.Errorf("error while loading string for unlockhash #%d: %v", idx, err)
+		}
+		str := uh.String()
+		if testCase != str {
+			t.Errorf("unlockhash #%d string loading isn't deterministic: %s != %s", idx, testCase, str)
 		}
 	}
 }

--- a/pkg/client/atomicswap.go
+++ b/pkg/client/atomicswap.go
@@ -661,10 +661,25 @@ func getSpendableKey(unlockHash types.UnlockHash) (types.SiaPublicKey, types.Byt
 	if err != nil {
 		Die("Could not get a matching wallet public/secret key pair for the given unlock hash:", err)
 	}
+	if isNilByteSlice(resp.PublicKey) {
+		Die("Could not get a wallet public key pair for the given unlock hash")
+	}
+	if isNilByteSlice(resp.SecretKey) {
+		Die("Received matching public key, but no secret key was returned, is your wallet unlocked?!")
+	}
 	return types.SiaPublicKey{
 		Algorithm: resp.AlgorithmSpecifier,
 		Key:       resp.PublicKey,
 	}, resp.SecretKey
+}
+
+func isNilByteSlice(bs types.ByteSlice) bool {
+	for _, b := range bs {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 // commitTxn sends a transaction to the used node's transaction pool

--- a/pkg/client/atomicswap.go
+++ b/pkg/client/atomicswap.go
@@ -99,10 +99,10 @@ var (
 		sourceUnlockHash types.UnlockHash
 	}
 	atomicSwapAuditcfg struct {
-		ParticipatorAddress types.UnlockHash
-		CoinAmount          coinFlag
-		HashedSecret        types.AtomicSwapHashedSecret
-		MinDurationLeft     time.Duration
+		ReceiverAddress types.UnlockHash
+		CoinAmount      coinFlag
+		HashedSecret    types.AtomicSwapHashedSecret
+		MinDurationLeft time.Duration
 	}
 	atomicSwapExtractSecretcfg struct {
 		HashedSecret types.AtomicSwapHashedSecret
@@ -392,14 +392,14 @@ TimeLock reached in: %s
 				atomicSwapAuditcfg.HashedSecret.String() + "!")
 		}
 	}
-	if atomicSwapAuditcfg.ParticipatorAddress != (types.UnlockHash{}) {
+	if atomicSwapAuditcfg.ReceiverAddress != (types.UnlockHash{}) {
 		// optionally validate participator's address (unlockhash)
-		if atomicSwapAuditcfg.ParticipatorAddress.Cmp(condition.Receiver) != 0 {
+		if atomicSwapAuditcfg.ReceiverAddress.Cmp(condition.Receiver) != 0 {
 			invalidContract = true
-			fmt.Println("Found contract's participator's address " +
+			fmt.Println("Found contract's receiver's address " +
 				condition.Receiver.String() +
-				" does not match the expected participator's address " +
-				atomicSwapAuditcfg.ParticipatorAddress.String() + "!")
+				" does not match the expected receiver's address " +
+				atomicSwapAuditcfg.ReceiverAddress.String() + "!")
 		}
 	}
 	if atomicSwapAuditcfg.MinDurationLeft != 0 {
@@ -794,8 +794,8 @@ func init() {
 		cli.StringLoaderFlag{StringLoader: &atomicSwapAuditcfg.HashedSecret}, "secrethash",
 		"optionally validate the expected secret hash to the secret hash of the found atomic swap contract condition")
 	atomicSwapAuditCmd.Flags().Var(
-		cli.StringLoaderFlag{StringLoader: &atomicSwapAuditcfg.ParticipatorAddress}, "participator",
-		"optionally validate the given participator's address (unlockhash) to the one found in the atomic swap contract condition")
+		cli.StringLoaderFlag{StringLoader: &atomicSwapAuditcfg.ReceiverAddress}, "receiver",
+		"optionally validate the given receiver's address (unlockhash) to the one found in the atomic swap contract condition")
 	atomicSwapAuditCmd.Flags().Var(
 		&atomicSwapAuditcfg.CoinAmount, "amount",
 		"optionally validate the given coin amount to the one found in the unspent coin output")

--- a/pkg/client/atomicswap.go
+++ b/pkg/client/atomicswap.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/rivine/rivine/api"
+	"github.com/rivine/rivine/pkg/cli"
 	"github.com/rivine/rivine/types"
 	"github.com/spf13/cobra"
 )
@@ -22,15 +23,15 @@ var (
 	}
 
 	atomicSwapParticipateCmd = &cobra.Command{
-		Use:   "participate dest amount hashedsecret",
+		Use:   "participate <initiator address> <amount> <secret hash>",
 		Short: "Create an atomic swap contract as participant.",
 		Long: `Create an atomic swap contract as a participant,
-using the hashed secret given by the initiator.`,
+using the secret hash given by the initiator.`,
 		Run: Wrap(atomicswapparticipatecmd),
 	}
 
 	atomicSwapInitiateCmd = &cobra.Command{
-		Use:   "initiate dest amount",
+		Use:   "initiate <participant address> <amount>",
 		Short: "Create an atomic swap contract as initiator.",
 		Long: `Create an atomic swap contract as an initiator,
 such that you can share its public information with the participant.`,
@@ -38,73 +39,77 @@ such that you can share its public information with the participant.`,
 	}
 
 	atomicSwapAuditCmd = &cobra.Command{
-		Use:   "audit outputid|unlockhash dest src timelock hashedsecret [amount]",
+		Use:   "auditcontract outputid",
 		Short: "Audit a created atomic swap contract.",
 		Long: `Audit a created atomic swap contract.
 
-If the first parameter is an unlock hash,
-this command will only perform a quick audit,
-meaning it will simply check if the given unlock hash,
-matches the expected contract information.
+It will try to look for the given outputid in the consensus as an unspent coin output.
+Should it not be find as an unspent output it will try to look in the transaction pool
+as to confirm it might be not part of a created block yet.
 
-If the first parameter is an outputID
-the unlock hash will be retrieved from an edge copy of the blockchain,
-using a local/remote explorer-enabled node,
-optionally validating the amount of coins attached to the contract as well.
-On top of that will ensure to check that the contract hasn't been spend yet.
+Optionally the participant's address, currency amount and secret hash can be validated,
+by giving one, some or all of them as flag arguments.
+
+Should an unspent atomic swap contract be found, it will be printed to the STDOUT formatted
+in a human-optimized format.
 `,
 		Run: atomicswapauditcmd,
 	}
 
 	atomicSwapExtractSecretCmd = &cobra.Command{
-		Use:   "extractsecret outputid [hashedsecret]",
-		Short: "Extract the secret from a claimed swap contract.",
-		Long: `Extract the secret from a claimed atomic swap contract,
-by looking up the outputID, ensuring it is spend (as otherwise it cannot be claimed),
-and retrieving the secret that was given part of a claim.
+		Use:   "extractsecret transactionid [outputid]",
+		Short: "Extract the secret from a redeemed swap contract.",
+		Long: `Extract the secret from a redeemed atomic swap contract.
+
+It will look for a transaction in the consensus set, using the given transactionID.
+The transaction should contain at least one atomic swap contract fulfillment.
+If an outputID is given, the (coin) input, from which the secret is to be extracted,
+has to have the given outputID as parent ID, otherwise the first input is used,
+which has an atomic swap contract fulfillment.
 
 If it was spend as a refund, than no secret can be extracted.
 
-Optionally the expected hashedsecret can be given, as to ensure that the
-hashed secret is as expected, and also matches the found/extracted secret.`,
+Optionally the expected hashedsecret can be given (as a flag), as to ensure that the
+secret hash is as expected, and also matches the found/extracted secret.`,
 		Run: atomicswapextractsecretcmd,
 	}
 
-	atomicSwapClaimCmd = &cobra.Command{
-		Use:   "claim outputid secret [dest src timelock hashedsecret] amount",
-		Short: "Claim the coins locked in an atomic swap contract.",
-		Long:  "Claim the coins locked in an atomic swap contract intended for you.",
-		Run:   atomicswapclaimcmd,
+	atomicSwapRedeemCmd = &cobra.Command{
+		Use:   "redeem outputid secret",
+		Short: "Redeem the coins locked in an atomic swap contract.",
+		Long:  "Redeem the coins locked in an atomic swap contract intended for you.",
+		Run:   Wrap(atomicswapredeemcmd),
 	}
 
 	atomicSwapRefundCmd = &cobra.Command{
-		Use:   "refund outputid [dest src timelock hashedsecret] amount",
+		Use:   "refund outputid",
 		Short: "Refund the coins locked in an atomic swap contract.",
 		Long:  "Refund the coins locked in an atomic swap contract created by you.",
-		Run:   atomicswaprefundcmd,
+		Run:   Wrap(atomicswaprefundcmd),
 	}
 )
 
 var (
 	atomicSwapParticipatecfg struct {
 		duration         time.Duration
-		sourceUnlockHash unlockHashFlag
+		sourceUnlockHash types.UnlockHash
 	}
 	atomicSwapInitiatecfg struct {
 		duration         time.Duration
-		sourceUnlockHash unlockHashFlag
+		sourceUnlockHash types.UnlockHash
 	}
-	atomicSwapClaimcfg struct {
-		audit  bool
-		legacy bool
+	atomicSwapAuditcfg struct {
+		ParticipatorAddress types.UnlockHash
+		CoinAmount          coinFlag
+		HashedSecret        types.AtomicSwapHashedSecret
+		MinDurationLeft     time.Duration
 	}
-	atomicSwapRefundcfg struct {
-		audit  bool
-		legacy bool
+	atomicSwapExtractSecretcfg struct {
+		HashedSecret types.AtomicSwapHashedSecret
 	}
 )
 
-func atomicswapparticipatecmd(dest, amount, hashedSecret string) {
+func atomicswapparticipatecmd(participantAddress, amount, hashedSecret string) {
 	var (
 		condition types.AtomicSwapCondition
 	)
@@ -118,14 +123,14 @@ func atomicswapparticipatecmd(dest, amount, hashedSecret string) {
 		Die("Cannot create atomic swap contract! Contracts which lock a value less than or equal to miner fees are currently not supported!")
 	}
 
-	err = condition.Receiver.LoadString(dest)
+	err = condition.Receiver.LoadString(participantAddress)
 	if err != nil {
-		Die("Could not parse destination address (unlock hash):", err)
+		Die("Could not parse participant address (unlock hash):", err)
 	}
 
-	if atomicSwapParticipatecfg.sourceUnlockHash.UnlockHash.Type != 0 {
+	if atomicSwapParticipatecfg.sourceUnlockHash.Type != 0 {
 		// use the hash given by the user explicitly
-		condition.Sender = atomicSwapParticipatecfg.sourceUnlockHash.UnlockHash
+		condition.Sender = atomicSwapParticipatecfg.sourceUnlockHash
 	} else {
 		// get new one from the wallet
 		resp := new(api.WalletAddressGET)
@@ -139,10 +144,10 @@ func atomicswapparticipatecmd(dest, amount, hashedSecret string) {
 	if hsl := len(hashedSecret); hsl == types.AtomicSwapHashedSecretLen*2 {
 		_, err := hex.Decode(condition.HashedSecret[:], []byte(hashedSecret))
 		if err != nil {
-			Die("Invalid hashed secret:", err)
+			Die("Invalid secret hash:", err)
 		}
 	} else {
-		Die("Invalid hashed secret length")
+		Die("Invalid secret hash length")
 	}
 	if atomicSwapParticipatecfg.duration == 0 {
 		Die("Duration is required")
@@ -185,9 +190,10 @@ func atomicswapparticipatecmd(dest, amount, hashedSecret string) {
 	}
 	fmt.Println("published contract transaction")
 	fmt.Println("OutputID:", response.Transaction.CoinOutputID(uint64(coinOutputIndex)))
+	fmt.Println("TransactionID:", response.Transaction.ID())
 }
 
-func atomicswapinitiatecmd(dest, amount string) {
+func atomicswapinitiatecmd(participatorAddress, amount string) {
 	var (
 		condition types.AtomicSwapCondition
 	)
@@ -201,14 +207,14 @@ func atomicswapinitiatecmd(dest, amount string) {
 		Die("Cannot create atomic swap contract! Contracts which lock a value less than or equal to miner fees are currently not supported!")
 	}
 
-	err = condition.Receiver.LoadString(dest)
+	err = condition.Receiver.LoadString(participatorAddress)
 	if err != nil {
-		Die("Could not parse destination address (unlock hash):", err)
+		Die("Could not parse participator address (unlock hash):", err)
 	}
 
-	if atomicSwapInitiatecfg.sourceUnlockHash.UnlockHash.Type != 0 {
+	if atomicSwapInitiatecfg.sourceUnlockHash.Type != 0 {
 		// use the hash given by the user explicitly
-		condition.Sender = atomicSwapInitiatecfg.sourceUnlockHash.UnlockHash
+		condition.Sender = atomicSwapInitiatecfg.sourceUnlockHash
 	} else {
 		// get new one from the wallet
 		resp := new(api.WalletAddressGET)
@@ -266,248 +272,219 @@ func atomicswapinitiatecmd(dest, amount string) {
 	}
 	fmt.Println("published contract transaction")
 	fmt.Println("OutputID:", response.Transaction.CoinOutputID(uint64(coinOutputIndex)))
+	fmt.Println("TransactionID:", response.Transaction.ID())
 }
 
 func atomicswapauditcmd(cmd *cobra.Command, args []string) {
 	argn := len(args)
-	if argn < 5 || argn > 6 {
+	if argn < 1 || argn > 2 {
 		cmd.UsageFunc()(cmd)
-		os.Exit(exitCodeUsage)
+		os.Exit(ExitCodeUsage)
 	}
 
-	var condition types.AtomicSwapCondition
-	err := condition.Receiver.LoadString(args[1])
+	var (
+		outputID      types.CoinOutputID
+		transactionID types.TransactionID
+	)
+
+	err := outputID.LoadString(args[0])
 	if err != nil {
-		Die("failed to parse dst-argument:", err)
+		Die("failed to parse required positional (coin) outputID argument:", err)
 	}
-	err = condition.Sender.LoadString(args[2])
-	if err != nil {
-		Die("failed to parse src-argument:", err)
-	}
-	err = condition.TimeLock.LoadString(args[3])
-	if err != nil {
-		Die("failed to parse timelock-argument:", err)
-	}
-	err = condition.HashedSecret.LoadString(args[4])
-	if err != nil {
-		Die("failed to parse hashedsecret-argument:", err)
+	if argn == 2 {
+		err = transactionID.LoadString(args[1])
+		if err != nil {
+			Die("failed to parse optional positional transactionID argument:", err)
+		}
 	}
 
-	// try to interpret the first param as an unlock hash
-	var expectedUH types.UnlockHash
-	if err = expectedUH.LoadString(args[0]); err == nil {
-		// do a quick check!
-		atomicswapauditcmdFast(expectedUH, condition)
+	// get unspent output from consensus
+	var unspentCoinOutputResp api.ConsensusGetUnspentCoinOutput
+	err = _DefaultClient.httpClient.GetAPI("/consensus/unspent/coinoutputs/"+outputID.String(), &unspentCoinOutputResp)
+	if err == nil {
+		auditAtomicSwapContract(unspentCoinOutputResp.Output, true)
 		return
 	}
-
-	// try to interpret the first param as an outputID
-	var outputID types.CoinOutputID
-	if err = outputID.LoadString(args[0]); err == nil {
-		var amount types.Currency // hastings or block stakes
-		if argn == 6 {
-			amount, err = _CurrencyConvertor.ParseCoinString(args[5])
-			if err != nil {
-				Die("failed to parse optional amount-argument:", err)
+	if err != errStatusNotFound {
+		Die("Unexpected error occured while getting (unspent) coin output from consensus:", err)
+	}
+	// output couldn't be found as an unspent coin output
+	// therefore the last positive hope is if it wasn't yet part of the transaction pool
+	var txnPoolGetResp api.TransactionPoolGET
+	err = _DefaultClient.httpClient.GetAPI("/transactionpool/transactions", &txnPoolGetResp)
+	if err != nil {
+		Die("Contract couldn't be found as part of an unspent coin output, and getting unconfirmed transactions from the transactionpool failed:", err)
+	}
+	for _, txn := range txnPoolGetResp.Transactions {
+		for idx, co := range txn.CoinOutputs {
+			coid := txn.CoinOutputID(uint64(idx))
+			if coid == outputID {
+				auditAtomicSwapContract(co, false)
+				return
 			}
 		}
-		// do a complete check! feels good, no?
-		atomicswapauditcmdComplete(outputID, &condition, amount)
+	}
+	// given that we could have just hit the unlucky window,
+	// where the block might have been just created in between our 2 calls,
+	// let's try to get the coin output one last time from the consensus
+	// contract couldn't be found as either
+	err = _DefaultClient.httpClient.GetAPI("/consensus/unspent/coinoutputs/"+outputID.String(), &unspentCoinOutputResp)
+	if err == nil {
+		auditAtomicSwapContract(unspentCoinOutputResp.Output, true)
 		return
 	}
+	if err != errStatusNotFound {
+		Die("Unexpected error occured while getting (unspent) coin output from consensus (a second try):", err)
+	}
+	fmt.Printf(`Failed to find atomic swap contract using outputid %s.
+It couldn't be found as part of a confirmed and unspent coin output in the consensus set,
+neither could it be found as an unconfirmed coin output in the transaction pool.
 
-	cmd.UsageFunc()(cmd)
-	Die("first parameter has to be valid and be either an unlock hash or an outputID")
+This might mean one of 2 things:
+
++ Most likely it means that the given outputID is invalid;
++ It might instead mean that the atomic swap contract was already refunded or redeemed,
+  this can be confirmed by looking the outputID up in a local, remote or public explorer;
+`, outputID)
+	DieWithExitCode(ExitCodeNotFound, "No unspent coin output could be found for ID "+outputID.String())
 }
 
-// atomicswapauditcmdFast only ensures that the given unlock hash matches the given AS condition
-func atomicswapauditcmdFast(expectedUH types.UnlockHash, condition types.AtomicSwapCondition) {
-	if expectedUH.Type != types.UnlockTypeAtomicSwap {
-		Die("The given unlock has is not of the atomic swap (unlock) type!")
-	}
-
-	uh := condition.UnlockHash()
-	if expectedUH.Cmp(uh) != 0 {
-		Die("Invalid contract! Given contract information does NOT match the given unlock hash!")
-	}
-
-	fmt.Println("Given unlock hash matches the given contract information :)")
-	fmt.Println("")
-	printContractInfo(types.Currency{}, condition, types.AtomicSwapSecret{})
-	fmt.Println("")
-	fmt.Println("This was a quick check only, whether it has been spend already or not is unclear.")
-	fmt.Println("You can do a complete/thorough check when auditing using the output ID instead.")
-}
-
-// atomicswapauditcmdComplete ensures that an output exists for the given outputID,
-// that the unlock hash of that output matches the given AS condition
-// and, last but not least, it ensures that this found output hasn't been spend yet
-// (but seriously, why would it?)
-func atomicswapauditcmdComplete(outputID types.CoinOutputID, conditionRef *types.AtomicSwapCondition, amount types.Currency) (parentTransaction types.Transaction) {
-	// get output info from explorer
-	resp := new(api.ExplorerHashGET)
-	err := _DefaultClient.httpClient.GetAPI("/explorer/hashes/"+outputID.String(), resp)
-	if err != nil {
-		Die("Could not get blockStake/coin output from explorer:", err)
-	}
-
-	switch tln := len(resp.Transactions); tln {
-	case 1:
-		txn := resp.Transactions[0]
-		parentTransaction = txn.RawTransaction
-
-		// when we receive 1 transaction,
-		// we'll assume that the output (atomic swap contract) hasn't been spend yet
-		expectedUnlockHash := types.NilUnlockHash
-		if conditionRef != nil {
-			expectedUnlockHash = conditionRef.UnlockHash()
-		} else {
-			for i, id := range resp.Transactions[0].CoinOutputIDs {
-				if bytes.Compare(id[:], outputID[:]) == 0 {
-					expectedUnlockHash = resp.Transactions[0].RawTransaction.CoinOutputs[i].Condition.UnlockHash()
-					break
-				}
-			}
-		}
-		var condition types.AtomicSwapCondition
-		switch resp.HashType {
-		case api.HashTypeCoinOutputIDStr:
-			condition = auditAtomicSwapCoinOutput(txn, outputID, expectedUnlockHash, amount)
-		default:
-			Die("Received unexpected hash type for given output ID:", resp.HashType)
-		}
-
-		fmt.Println("An unspend atomic swap contract could be found for the given outputID,")
-		fmt.Println("and the given contract information matches the found contract's information, all good! :)")
-		fmt.Println("")
-		printContractInfo(types.Currency{}, condition, types.AtomicSwapSecret{})
-
-	case 2:
-		// when we receive 2 transactions,
-		// we'll assume that output (atomic swap contract) has been spend already
-		// try to find the transactionID, so we can tell which one it was spend
-		switch resp.HashType {
-		case api.HashTypeCoinOutputIDStr:
-			auditAtomicSwapFindSpendCoinTransactionID(types.CoinOutputID(outputID), resp.Transactions)
-		default:
-			Die("Requested output was found, but already spend, and received unexpected hash type for given output ID:", resp.HashType)
-		}
-
-	default:
-		Die("Unexpected amount (BUG?!) of returned transactions for given outputID:", tln)
-	}
-
-	return
-}
-func auditAtomicSwapCoinOutput(txn api.ExplorerTransaction, expectedCoinOutputID types.CoinOutputID, expectedUH types.UnlockHash, expectedHastings types.Currency) types.AtomicSwapCondition {
-	coinOutputIndex := -1
-	for idx, co := range txn.CoinOutputIDs {
-		if bytes.Compare(co[:], expectedCoinOutputID[:]) == 0 {
-			coinOutputIndex = idx
-			break
-		}
-	}
-	if coinOutputIndex == -1 {
-		Die("Couldn't find expected coin outputID in retrieved transaction's coin outputs! BUG?!") // unexpected, bug?
-	}
-	if len(txn.RawTransaction.CoinOutputs) == 0 || len(txn.RawTransaction.CoinOutputs) < coinOutputIndex {
-		Die("Retrieved transaction for given coin output ID has returned insufficient amount of coin outputs to check! BUG?!") // unexpected, bug?
-	}
-	coinOutput := txn.RawTransaction.CoinOutputs[coinOutputIndex]
-
-	condition, ok := coinOutput.Condition.Condition.(*types.AtomicSwapCondition)
+func auditAtomicSwapContract(co types.CoinOutput, confirmed bool) {
+	condition, ok := co.Condition.Condition.(*types.AtomicSwapCondition)
 	if !ok {
-		Die(fmt.Sprintf("The found coin output's condition type (%T) is not of the atomic swap type!", coinOutput.Condition.Condition))
+		Die(fmt.Sprintf(
+			"Received unexpected condition of type %T, while type *types.AtomicSwapCondition was expected in order to be able to audit",
+			co.Condition.Condition))
 	}
+	durationLeft := time.Unix(int64(condition.TimeLock), 0).Sub(computeTimeNow())
 
-	if condition.UnlockHash().Cmp(expectedUH) != 0 {
-		Die("Invalid contract! The found coin output's unlock hash does not match the provided contract information!")
-	}
+	fmt.Printf(`Atomic Swap Contract (condition) found:
 
-	if expectedHastings.Equals64(0) {
-		fmt.Println("No amount hastings given to audit, skipping this audit step!")
-		return *condition // no hastings to audit
-	}
-	if !expectedHastings.Equals(coinOutput.Value) {
-		Die(fmt.Sprintf("Invalid Contract! expected %s but found %s registered in the found coin output instead!",
-			_CurrencyConvertor.ToCoinStringWithUnit(expectedHastings),
-			_CurrencyConvertor.ToCoinStringWithUnit(coinOutput.Value)))
-	}
+Contract value: %s
 
-	return *condition
-}
-func auditAtomicSwapFindSpendCoinTransactionID(coinOutputID types.CoinOutputID, txns []api.ExplorerTransaction) {
-	for _, txn := range txns {
-		for _, ci := range txn.RawTransaction.CoinInputs {
-			if bytes.Compare(coinOutputID[:], ci.ParentID[:]) == 0 {
-				Die("Atomic swap contract was already spend as a coin input! This as part of transaction:", txn.ID.String())
-			}
+Participator's address: %s
+Initiator's address: %s
+Secret Hash: %s
+TimeLock: %[5]d (%[5]s)
+TimeLock reached in: %s
+
+`, _CurrencyConvertor.ToCoinStringWithUnit(co.Value), condition.Receiver,
+		condition.Sender, condition.HashedSecret, condition.TimeLock, durationLeft)
+
+	var invalidContract bool
+	if !atomicSwapAuditcfg.CoinAmount.Amount.IsZero() {
+		// optionally validate coin amount
+		if !atomicSwapAuditcfg.CoinAmount.Amount.Equals(co.Value) {
+			invalidContract = true
+			fmt.Println("Unspent out's value " +
+				_CurrencyConvertor.ToCoinStringWithUnit(co.Value) +
+				" does not match the expected value " +
+				_CurrencyConvertor.ToCoinStringWithUnit(atomicSwapAuditcfg.CoinAmount.Amount) + "!")
 		}
 	}
-	Die("Atomic swap contract was already spend as a coin input! This as part of an unknown transaction (BUG!?)")
+	if atomicSwapAuditcfg.HashedSecret != (types.AtomicSwapHashedSecret{}) {
+		// optionally validate hashed secret
+		if atomicSwapAuditcfg.HashedSecret != condition.HashedSecret {
+			invalidContract = true
+			fmt.Println("Found contract's secret hash " +
+				condition.HashedSecret.String() +
+				" does not match the expected secret hash " +
+				atomicSwapAuditcfg.HashedSecret.String() + "!")
+		}
+	}
+	if atomicSwapAuditcfg.ParticipatorAddress != (types.UnlockHash{}) {
+		// optionally validate participator's address (unlockhash)
+		if atomicSwapAuditcfg.ParticipatorAddress.Cmp(condition.Receiver) != 0 {
+			invalidContract = true
+			fmt.Println("Found contract's participator's address " +
+				condition.Receiver.String() +
+				" does not match the expected participator's address " +
+				atomicSwapAuditcfg.ParticipatorAddress.String() + "!")
+		}
+	}
+	if atomicSwapAuditcfg.MinDurationLeft != 0 {
+		// optionally validate participator's address (unlockhash)
+		if durationLeft < atomicSwapAuditcfg.MinDurationLeft {
+			invalidContract = true
+			fmt.Println("Found contract's duration left " +
+				durationLeft.String() +
+				" is not sufficient, when compared the expected duration left of " +
+				atomicSwapAuditcfg.MinDurationLeft.String() + "!")
+		}
+	}
+	if invalidContract {
+		Die("Found Atomic Swap Contract does not meet the given expectations!")
+	}
+	fmt.Println("Found Atomic Swap Contract is valid :)")
+	if !confirmed {
+		fmt.Println("NOTE that this contract is still in the transaction pool and thus UNCONFIRMED!!!")
+	}
 }
 
-// extractsecret outputid [hashedsecret]
+// extractsecret transactionid [outputid]
 func atomicswapextractsecretcmd(cmd *cobra.Command, args []string) {
 	argn := len(args)
 	if argn < 1 || argn > 2 {
 		cmd.UsageFunc()(cmd)
-		os.Exit(exitCodeUsage)
+		os.Exit(ExitCodeUsage)
 	}
 
 	var (
-		outputID             types.OutputID
-		expectedHashedSecret types.AtomicSwapHashedSecret
+		txnID         types.TransactionID
+		outputID      types.CoinOutputID
+		outputIDGiven bool
+		secret        types.AtomicSwapSecret
 	)
-	err := outputID.LoadString(args[0])
+	err := txnID.LoadString(args[0])
 	if err != nil {
-		Die("Couldn't parse first argment as an output ID:", err)
+		Die("Couldn't parse first argment as a transaction (long) ID:", err)
 	}
 	if argn == 2 {
-		err := expectedHashedSecret.LoadString(args[1])
+		err = outputID.LoadString(args[1])
 		if err != nil {
-			Die("Couldn't parse second argment as a hashed secret:", err)
+			Die("Couldn't parse optional second argment as a coin outputID:", err)
 		}
+		outputIDGiven = true
 	}
 
-	// get output info from explorer
-	resp := new(api.ExplorerHashGET)
-	err = _DefaultClient.httpClient.GetAPI("/explorer/hashes/"+outputID.String(), resp)
+	// get transaction from consensus
+	var txnResp api.ConsensusGetTransaction
+	err = _DefaultClient.httpClient.GetAPI("/consensus/transactions/"+txnID.String(), &txnResp)
 	if err != nil {
-		Die("Could not get blockStake/coin output from explorer:", err)
+		Die("failed to get transaction:", err, "; Long ID:", txnID)
 	}
 
-	switch tln := len(resp.Transactions); tln {
-	case 1:
-		Die("Cannot extract secret! Atomic swap contract has not yet been claimed!")
-
-	case 2:
-		// when we receive 2 transactions,
-		// we'll assume that output (atomic swap contract) has been spend already
-		// try to get the secret, which is possible if it was clamed
-		var secret types.AtomicSwapSecret
-		switch resp.HashType {
-		case api.HashTypeCoinOutputIDStr:
-			secret = auditAtomicSwapFindSpendCoinSecret(types.CoinOutputID(outputID), resp.Transactions)
-		case api.HashTypeBlockStakeOutputIDStr:
-			secret = auditAtomicSwapFindSpendBlockStakeSecret(types.BlockStakeOutputID(outputID), resp.Transactions)
-		default:
-			Die("Cannot extract secret! Requested output was found and already spend, but received unexpected hash type for given output ID:", resp.HashType)
+	// get the secret from any of the inputs within this transaction, if possible,
+	// or from an input which doesn't just define the right fulfillment but also has the right parentID
+	for _, ci := range txnResp.CoinInputs {
+		if outputIDGiven && ci.ParentID != outputID {
+			continue
 		}
-		if secret == (types.AtomicSwapSecret{}) {
-			Die("Atomic swap contract was spend as a refund, not a claim! No secret can be extracted!")
+		if ft := ci.Fulfillment.FulfillmentType(); ft != types.FulfillmentTypeAtomicSwap {
+			continue
 		}
-
-		// no need to verify the secret ourselves,
-		// as the secret is already guaranteed to be correct,
-		// given it is part of the blockchain and validated as part of the creation and syncing.
-
-		fmt.Println("Atomic swap contract was claimed by recipient! Success! :)")
-		fmt.Println("Extracted secret:", secret.String())
-
-	default:
-		Die("Cannot extract secret! Unexpected amount (BUG?!) of returned transactions for given outputID:", tln)
+		getter, ok := ci.Fulfillment.Fulfillment.(atomicSwapSecretGetter)
+		if !ok {
+			Die(fmt.Sprintf(
+				"Received unexpected fulfillment type of type %T", ci.Fulfillment.Fulfillment))
+		}
+		secret = getter.AtomicSwapSecret()
+		break
 	}
+	if secret == (types.AtomicSwapSecret{}) {
+		Die("Couldn't find a matching atomic swap contract fulfillment in transaction with LongID: ", txnID)
+	}
+
+	if atomicSwapExtractSecretcfg.HashedSecret != (types.AtomicSwapHashedSecret{}) {
+		hs := types.NewAtomicSwapHashedSecret(secret)
+		if hs != atomicSwapExtractSecretcfg.HashedSecret {
+			Die(fmt.Sprintf("found secret %s does not match expected and given secret hash %s",
+				secret, atomicSwapExtractSecretcfg.HashedSecret))
+		}
+	}
+
+	fmt.Println("Atomic swap contract was redeemed by participator! Success! :)")
+	fmt.Println("Extracted secret:", secret.String())
 }
 
 type atomicSwapSecretGetter interface {
@@ -545,239 +522,89 @@ func auditAtomicSwapFindSpendBlockStakeSecret(blockStakeOutputID types.BlockStak
 	return types.AtomicSwapSecret{}
 }
 
-// claim outputid secret [dest src timelock hashedsecret amount]
-func atomicswapclaimcmd(cmd *cobra.Command, args []string) {
+// redeem outputid secret
+func atomicswapredeemcmd(outputIDStr, secretStr string) {
 	var (
-		err          error
-		outputID     types.CoinOutputID
-		secret       types.AtomicSwapSecret
-		conditionRef *types.AtomicSwapCondition
-		hastings     types.Currency
+		err      error
+		outputID types.CoinOutputID
+		secret   types.AtomicSwapSecret
 	)
 
-	// step 1: parse all arguments and prepare transaction primitives
-	switch len(args) {
-	case 3:
-		hastings, err = _CurrencyConvertor.ParseCoinString(args[2])
-		if err != nil {
-			Die("failed to parse amount-argument as coins:", err)
-		}
-		atomicSwapClaimcfg.audit = true // enforce auditing, such that we can get condition via there
-
-	case 7:
-		condition := getAtomicSwapRedeemConditionFromOptPosArgs(args[2:6])
-		conditionRef = &condition
-
-		hastings, err = _CurrencyConvertor.ParseCoinString(args[6])
-		if err != nil {
-			Die("failed to parse amount-argument as coins:", err)
-		}
-
-	default:
-		cmd.UsageFunc()(cmd)
-		Die("Invalid amount of positional arguments given!")
-	}
-
-	// parse common pos args
-	err = outputID.LoadString(args[0])
+	// parse pos args
+	err = outputID.LoadString(outputIDStr)
 	if err != nil {
 		Die("failed to parse outputid-argument:", err)
 	}
-	err = secret.LoadString(args[1])
+	err = secret.LoadString(secretStr)
 	if err != nil {
 		Die("failed to parse secret-argument:", err)
 	}
-
-	// optional step: audit contract
-	if atomicSwapClaimcfg.audit {
-		// overwrite our flag
-		parentTransaction := atomicswapauditcmdComplete(outputID, conditionRef, hastings)
-		atomicSwapClaimcfg.legacy = parentTransaction.Version == types.TransactionVersionZero
-
-		// NOTE: for now we hardcode this for coins, as we only support contracts with coins in this cmd
-		for idx, co := range parentTransaction.CoinOutputs {
-			if parentTransaction.CoinOutputID(uint64(idx)) == outputID {
-				var ok bool
-				conditionRef, ok = co.Condition.Condition.(*types.AtomicSwapCondition)
-				if !ok {
-					Die("unexpected condition for coin output parent ID")
-				}
-			}
-		}
-
-		if conditionRef == nil {
-			Die("atomic swap condition could not be find in parent coin output with ID " + outputID.String())
-		}
+	if secret == (types.AtomicSwapSecret{}) {
+		Die("secret cannot be all-nil when redeeming an atomic swap contract")
 	}
 
-	// step 2: get correct spendable key from wallet
-	pk, sk := getSpendableKey(conditionRef.Receiver)
-	// quickly validate if returned sk matches the known unlock hash (sanity check)
-	uh := types.NewPubKeyUnlockHash(pk)
-	if uh.Cmp(conditionRef.Receiver) != 0 {
-		Die("Unexpected wallet public key returned:", sk)
-	}
-
-	if hastings.Cmp(_MinimumTransactionFee) != 1 {
-		Die("Cannot claim atomic swap contract! Contracts which lock a value less than or equal to miner fees are currently not supported!")
-	}
-
-	// step 3: confirm contract details with user, before continuing
-	// print contract for review
-	if !atomicSwapClaimcfg.audit {
-		// only print again, if not printed already
-		printContractInfo(hastings, *conditionRef, secret)
-	}
-	fmt.Println("")
-	// ensure user wants to continue with claiming the contract!
-	if !askYesNoQuestion("Publish atomic swap claim transaction?") {
-		Die("Atomic swap claim transaction cancelled!")
-	}
-
-	// step 4: create a transaction
-	txn := types.Transaction{
-		Version: _DefaultTransactionVersion,
-		CoinInputs: []types.CoinInput{
-			{
-				ParentID: outputID,
-				Fulfillment: types.NewFulfillment(func() types.MarshalableUnlockFulfillment {
-					if atomicSwapClaimcfg.legacy {
-						return &types.LegacyAtomicSwapFulfillment{
-							Sender:       conditionRef.Sender,
-							Receiver:     conditionRef.Receiver,
-							HashedSecret: conditionRef.HashedSecret,
-							TimeLock:     conditionRef.TimeLock,
-							PublicKey:    pk,
-							Secret:       secret,
-						}
-					}
-					return &types.AtomicSwapFulfillment{
-						PublicKey: pk,
-						Secret:    secret,
-					}
-				}()),
-			},
-		},
-		CoinOutputs: []types.CoinOutput{
-			{
-				Condition: types.NewCondition(types.NewUnlockHashCondition(uh)),
-				Value:     hastings.Sub(_MinimumTransactionFee),
-			},
-		},
-		MinerFees: []types.Currency{_MinimumTransactionFee},
-	}
-
-	// step 5: sign transaction's only input
-	err = txn.CoinInputs[0].Fulfillment.Sign(types.FulfillmentSignContext{
-		InputIndex:  0,
-		Transaction: txn,
-		Key:         sk,
-	})
-	if err != nil {
-		Die("Cannot claim atomic swap's locked coins! Couldn't sign transaction:", err)
-	}
-	if uh.Cmp(conditionRef.Receiver) != 0 {
-		Die("Cannot claim atomic swap's locked coins! Wrong wallet key-pair received:", uh)
-	}
-
-	// step 6: submit transaction to transaction pool and celebrate if possible
-	txnid, err := commitTxn(txn)
-	if err != nil {
-		Die("Failed to claim atomic swaps locked tokens, as transaction couldn't commit:", err)
-	}
-
-	fmt.Println("")
-	fmt.Println("Published atomic swap claim transaction!")
-	fmt.Println("Transaction ID:", txnid)
-	fmt.Println(`>   NOTE that this does NOT mean for 100% you'll have the money!
-> Due to potential forks, double spending, and any other possible issues your
-> claim might be declined by the network. Please check the network
-> (e.g. using a public explorer node or your own full node) to ensure
-> your payment went through. If not, try to audit the contract (again).`)
+	spendAtomicSwapContract(outputID, secret)
 }
 
-// refund outputid [dest src timelock hashedsecret amount]
-func atomicswaprefundcmd(cmd *cobra.Command, args []string) {
+// refund outputid
+func atomicswaprefundcmd(outputIDStr string) {
 	var (
-		err          error
-		outputID     types.CoinOutputID
-		secret       types.AtomicSwapSecret
-		conditionRef *types.AtomicSwapCondition
-		hastings     types.Currency
+		err      error
+		outputID types.CoinOutputID
 	)
 
-	// step 1: parse all arguments and prepare transaction primitivesswitch len(args) {
-	switch len(args) {
-	case 2:
-		hastings, err = _CurrencyConvertor.ParseCoinString(args[1])
-		if err != nil {
-			Die("failed to parse amount-argument as coins:", err)
-		}
-		atomicSwapRefundcfg.audit = true // enforce auditing, such that we can get condition via there
-
-	case 6:
-		condition := getAtomicSwapRedeemConditionFromOptPosArgs(args[1:5])
-		conditionRef = &condition
-
-		hastings, err = _CurrencyConvertor.ParseCoinString(args[5])
-		if err != nil {
-			Die("failed to parse amount-argument as coins:", err)
-		}
-
-	default:
-		cmd.UsageFunc()(cmd)
-		Die("Invalid amount of positional arguments given!")
-	}
-
-	// parse common pos args
-	err = outputID.LoadString(args[0])
+	// parse pos arg
+	err = outputID.LoadString(outputIDStr)
 	if err != nil {
 		Die("failed to parse outputid-argument:", err)
 	}
 
-	// optional step: audit contract
-	if atomicSwapRefundcfg.audit {
-		// overwrite our flag
-		parentTransaction := atomicswapauditcmdComplete(outputID, conditionRef, hastings)
-		atomicSwapRefundcfg.legacy = parentTransaction.Version == types.TransactionVersionZero
+	spendAtomicSwapContract(outputID, types.AtomicSwapSecret{})
+}
 
-		// NOTE: for now we hardcode this for coins, as we only support contracts with coins in this cmd
-		for idx, co := range parentTransaction.CoinOutputs {
-			if parentTransaction.CoinOutputID(uint64(idx)) == outputID {
-				var ok bool
-				conditionRef, ok = co.Condition.Condition.(*types.AtomicSwapCondition)
-				if !ok {
-					Die("unexpected condition for coin output parent ID")
-				}
-			}
-		}
+func spendAtomicSwapContract(outputID types.CoinOutputID, secret types.AtomicSwapSecret) {
+	var keyWord string // define keyword for communication purposes
+	if secret == (types.AtomicSwapSecret{}) {
+		keyWord = "refund"
+	} else {
+		keyWord = "redeem"
+	}
 
-		if conditionRef == nil {
-			Die("atomic swap condition could not be find in parent coin output with ID " + outputID.String())
-		}
+	// get unspent output from consensus
+	var unspentCoinOutputResp api.ConsensusGetUnspentCoinOutput
+	err := _DefaultClient.httpClient.GetAPI("/consensus/unspent/coinoutputs/"+outputID.String(), &unspentCoinOutputResp)
+	if err != nil {
+		Die("Could not get unspent coinoutput from consensus:", err)
 	}
 
 	// step 2: get correct spendable key from wallet
-	pk, sk := getSpendableKey(conditionRef.Sender)
+	if ct := unspentCoinOutputResp.Output.Condition.ConditionType(); ct != types.ConditionTypeAtomicSwap {
+		Die("Only atomic swap conditions are supported, while referenced output is of type: ", ct)
+	}
+	condition, ok := unspentCoinOutputResp.Output.Condition.Condition.(*types.AtomicSwapCondition)
+	if !ok {
+		Die(fmt.Sprintf(
+			"Received unexpected condition of type %T, while type *types.AtomicSwapCondition was expected",
+			unspentCoinOutputResp.Output.Condition.Condition))
+	}
+	pk, sk := getSpendableKey(condition.Receiver)
 	// quickly validate if returned sk matches the known unlock hash (sanity check)
 	uh := types.NewPubKeyUnlockHash(pk)
-	if uh.Cmp(conditionRef.Sender) != 0 {
+	if uh.Cmp(condition.Receiver) != 0 {
 		Die("Unexpected wallet public key returned:", sk)
 	}
-	if hastings.Cmp(_MinimumTransactionFee) == -1 {
-		Die("Cannot refund atomic swap contract! Contracts which lock a value less than or equal to miner fees are currently not supported!")
+
+	if unspentCoinOutputResp.Output.Value.Cmp(_MinimumTransactionFee) != 1 {
+		Die("Cannot " + keyWord + " atomic swap contracts which lock a value less than or equal to miner fees are currently not supported!")
 	}
 
 	// step 3: confirm contract details with user, before continuing
 	// print contract for review
-	if !atomicSwapRefundcfg.audit {
-		// only print again, if not printed already
-		printContractInfo(hastings, *conditionRef, secret)
-	}
+	printContractInfo(unspentCoinOutputResp.Output.Value, *condition, secret)
 	fmt.Println("")
-	// ensure user wants to continue with refunding the contract!
-	if !askYesNoQuestion("Publish atomic swap refund transaction?") {
-		Die("Atomic swap refund transaction cancelled!")
+	// ensure user wants to continue with redeeming the contract!
+	if !askYesNoQuestion("Publish atomic swap " + keyWord + " transaction?") {
+		Die("Atomic swap " + keyWord + " transaction cancelled!")
 	}
 
 	// step 4: create a transaction
@@ -786,28 +613,16 @@ func atomicswaprefundcmd(cmd *cobra.Command, args []string) {
 		CoinInputs: []types.CoinInput{
 			{
 				ParentID: outputID,
-				Fulfillment: types.NewFulfillment(func() types.MarshalableUnlockFulfillment {
-					if atomicSwapRefundcfg.legacy {
-						return &types.LegacyAtomicSwapFulfillment{
-							Sender:       conditionRef.Sender,
-							Receiver:     conditionRef.Receiver,
-							HashedSecret: conditionRef.HashedSecret,
-							TimeLock:     conditionRef.TimeLock,
-							PublicKey:    pk,
-							// secret not needed for refund
-						}
-					}
-					return &types.AtomicSwapFulfillment{
-						PublicKey: pk,
-						// secret not needed for refund
-					}
-				}()),
+				Fulfillment: types.NewFulfillment(&types.AtomicSwapFulfillment{
+					PublicKey: pk,
+					Secret:    secret,
+				}),
 			},
 		},
 		CoinOutputs: []types.CoinOutput{
 			{
 				Condition: types.NewCondition(types.NewUnlockHashCondition(uh)),
-				Value:     hastings.Sub(_MinimumTransactionFee),
+				Value:     unspentCoinOutputResp.Output.Value.Sub(_MinimumTransactionFee),
 			},
 		},
 		MinerFees: []types.Currency{_MinimumTransactionFee},
@@ -820,49 +635,23 @@ func atomicswaprefundcmd(cmd *cobra.Command, args []string) {
 		Key:         sk,
 	})
 	if err != nil {
-		Die("Cannot refund atomic swap's locked coins! Couldn't sign transaction:", err)
-	}
-	if uh.Cmp(conditionRef.Sender) != 0 {
-		Die("Cannot refund atomic swap's locked coins! Wrong wallet key-pair received:", uh)
+		Die("Cannot "+keyWord+" atomic swap's locked coins! Couldn't sign transaction:", err)
 	}
 
 	// step 6: submit transaction to transaction pool and celebrate if possible
 	txnid, err := commitTxn(txn)
 	if err != nil {
-		Die("Failed to refund atomic swaps locked tokens, as transaction couldn't commit:", err)
+		Die("Failed to "+keyWord+" atomic swaps locked tokens, as transaction couldn't commit:", err)
 	}
 
 	fmt.Println("")
-	fmt.Println("Published atomic swap refund transaction!")
+	fmt.Println("Published atomic swap " + keyWord + " transaction!")
 	fmt.Println("Transaction ID:", txnid)
 	fmt.Println(`>   NOTE that this does NOT mean for 100% you'll have the money!
 > Due to potential forks, double spending, and any other possible issues your
-> refund might be declined by the network. Please check the network
+> ` + keyWord + ` might be declined by the network. Please check the network
 > (e.g. using a public explorer node or your own full node) to ensure
 > your payment went through. If not, try to audit the contract (again).`)
-}
-
-// getAtomicSwapRedeemConditionFromOptPosArgs parses the following 4 arguments in order:
-// dest src timelock hashedseret
-func getAtomicSwapRedeemConditionFromOptPosArgs(args []string) (condition types.AtomicSwapCondition) {
-	err := condition.Receiver.LoadString(args[0])
-	if err != nil {
-		Die("failed to parse dest-argument:", err)
-	}
-	err = condition.Sender.LoadString(args[1])
-	if err != nil {
-		Die("failed to parse src-argument:", err)
-	}
-	err = condition.TimeLock.LoadString(args[2])
-	if err != nil {
-		Die("failed to parse timelock-argument:", err)
-	}
-	err = condition.HashedSecret.LoadString(args[3])
-	if err != nil {
-		Die("failed to parse hashedsecret-argument:", err)
-	}
-
-	return
 }
 
 // get public- and private key from wallet module
@@ -907,13 +696,13 @@ Secret: %s`, secret)
 	cuh := condition.UnlockHash()
 
 	fmt.Printf(`Contract address: %s%s
-Recipient address: %s
-Refund address: %s
+Participator's address: %s
+Initiator's address: %s
 
-Hashed Secret: %s%s
+SecretHash: %s%s
 
-Locktime: %[7]d (%[7]s)
-Locktime reached in: %s
+TimeLock: %[7]d (%[7]s)
+TimeLock reached in: %s
 `, cuh, amountStr, condition.Receiver, condition.Sender, condition.HashedSecret,
 		secretStr, condition.TimeLock,
 		time.Unix(int64(condition.TimeLock), 0).Sub(time.Now()))
@@ -959,38 +748,37 @@ var (
 	nokayResponses = []string{"n", "no", "noo", "nope"}
 )
 
+var computeTimeNow = func() time.Time {
+	return time.Now()
+}
+
 func init() {
 	atomicSwapParticipateCmd.Flags().DurationVarP(
 		&atomicSwapParticipatecfg.duration, "duration", "d",
-		time.Hour*24, "the duration of the atomic swap contract, the amount of time the receiver has to collect")
-	atomicSwapParticipateCmd.Flags().Var(&atomicSwapParticipatecfg.sourceUnlockHash, "src",
-		"optionally define a source address that is to be used for refunding purposes, one will be generated for you if none is given")
+		time.Hour*24, "the duration of the atomic swap contract, the amount of time the participator has to collect")
+	atomicSwapParticipateCmd.Flags().Var(cli.StringLoaderFlag{StringLoader: &atomicSwapParticipatecfg.sourceUnlockHash}, "initiator",
+		"optionally define a wallet address (unlockhash) that is to be used for refunding purposes, one will be generated for you if none is given")
 
 	atomicSwapInitiateCmd.Flags().DurationVarP(
 		&atomicSwapInitiatecfg.duration, "duration", "d",
-		time.Hour*48, "the duration of the atomic swap contract, the amount of time the receiver has to collect")
-	atomicSwapInitiateCmd.Flags().Var(&atomicSwapInitiatecfg.sourceUnlockHash, "src",
-		"optionally define a source address that is to be used for refunding purposes, one will be generated for you if none is given")
+		time.Hour*48, "the duration of the atomic swap contract, the amount of time the participator has to collect")
+	atomicSwapInitiateCmd.Flags().Var(cli.StringLoaderFlag{StringLoader: &atomicSwapInitiatecfg.sourceUnlockHash}, "initiator",
+		"optionally define a wallet address (unlockhash) that is to be used for refunding purposes, one will be generated for you if none is given")
 
-	atomicSwapClaimCmd.Flags().BoolVar(&atomicSwapClaimcfg.audit, "audit", false,
-		"optionally audit the given contract information against the known contract info on the used explorer node")
-	atomicSwapClaimCmd.Flags().BoolVar(&atomicSwapClaimcfg.legacy, "legacy", false,
-		"defines if the to be created fulfillment has to be a legacy one, fulfilling a legacy atomic swap condition")
+	atomicSwapAuditCmd.Flags().Var(
+		cli.StringLoaderFlag{StringLoader: &atomicSwapAuditcfg.HashedSecret}, "secrethash",
+		"optionally validate the expected secret hash to the secret hash of the found atomic swap contract condition")
+	atomicSwapAuditCmd.Flags().Var(
+		cli.StringLoaderFlag{StringLoader: &atomicSwapAuditcfg.ParticipatorAddress}, "participator",
+		"optionally validate the given participator's address (unlockhash) to the one found in the atomic swap contract condition")
+	atomicSwapAuditCmd.Flags().Var(
+		&atomicSwapAuditcfg.CoinAmount, "amount",
+		"optionally validate the given coin amount to the one found in the unspent coin output")
+	atomicSwapAuditCmd.Flags().DurationVar(
+		&atomicSwapAuditcfg.MinDurationLeft, "min-duration", 0,
+		"optionally validate the given contract has sufficient duration left, as defined by the timelock in the found atomic swap contract condition")
 
-	atomicSwapRefundCmd.Flags().BoolVar(&atomicSwapRefundcfg.audit, "audit", false,
-		"optionally audit the given contract information against the known contract info on the used explorer node")
-	atomicSwapRefundCmd.Flags().BoolVar(&atomicSwapRefundcfg.legacy, "legacy", false,
-		"defines if the to be created fulfillment has to be a legacy one, fulfilling a legacy atomic swap condition")
-}
-
-type unlockHashFlag struct {
-	types.UnlockHash
-}
-
-func (uhf *unlockHashFlag) Set(str string) error {
-	return uhf.LoadString(str)
-}
-
-func (uhf unlockHashFlag) Type() string {
-	return "UnlockHash"
+	atomicSwapExtractSecretCmd.Flags().Var(
+		cli.StringLoaderFlag{StringLoader: &atomicSwapExtractSecretcfg.HashedSecret}, "secrethash",
+		"optionally validate the given secret hash with the secret hash of the found atomic swap contract condition")
 }

--- a/pkg/client/defaultclient.go
+++ b/pkg/client/defaultclient.go
@@ -14,8 +14,9 @@ import (
 // exit codes
 // inspired by sysexits.h
 const (
-	exitCodeGeneral = 1  // Not in sysexits.h, but is standard practice.
-	exitCodeUsage   = 64 // EX_USAGE in sysexits.h
+	ExitCodeGeneral  = 1 // Not in sysexits.h, but is standard practice.
+	ExitCodeNotFound = 2
+	ExitCodeUsage    = 64 // EX_USAGE in sysexits.h
 )
 
 // Config defines the configuration for the default (CLI) client.
@@ -62,7 +63,7 @@ func Wrap(fn interface{}) func(*cobra.Command, []string) {
 	return func(cmd *cobra.Command, args []string) {
 		if len(args) != fnType.NumIn() {
 			cmd.UsageFunc()(cmd)
-			os.Exit(exitCodeUsage)
+			os.Exit(ExitCodeUsage)
 		}
 		argVals := make([]reflect.Value, fnType.NumIn())
 		for i := range args {
@@ -75,8 +76,14 @@ func Wrap(fn interface{}) func(*cobra.Command, []string) {
 // Die prints its arguments to stderr, then exits the program with the default
 // error code.
 func Die(args ...interface{}) {
+	DieWithExitCode(ExitCodeGeneral, args...)
+}
+
+// DieWithExitCode prints its arguments to stderr,
+// then exits the program with the given exit code.
+func DieWithExitCode(code int, args ...interface{}) {
 	fmt.Fprintln(os.Stderr, args...)
-	os.Exit(exitCodeGeneral)
+	os.Exit(code)
 }
 
 // clientVersion prints the client version and exits
@@ -170,7 +177,7 @@ func DefaultCLIClient(cfg Config) {
 		atomicSwapInitiateCmd,
 		atomicSwapAuditCmd,
 		atomicSwapExtractSecretCmd,
-		atomicSwapClaimCmd,
+		atomicSwapRedeemCmd,
 		atomicSwapRefundCmd,
 	)
 
@@ -208,7 +215,7 @@ func DefaultCLIClient(cfg Config) {
 		// Command.RunE), Command.Execute() should only return an error on an
 		// invalid command or flag. Therefore Command.Usage() was called (assuming
 		// Command.SilenceUsage is false) and we should exit with exitCodeUsage.
-		os.Exit(exitCodeUsage)
+		os.Exit(ExitCodeUsage)
 	}
 }
 

--- a/pkg/client/flag.go
+++ b/pkg/client/flag.go
@@ -1,0 +1,34 @@
+package client
+
+import (
+	"github.com/rivine/rivine/types"
+	"github.com/spf13/pflag"
+)
+
+type coinFlag struct {
+	Amount types.Currency
+}
+
+// String implements pflag.Value.String,
+// printing this LockTime either as a timestamp in DateOnlyLayout or RFC822 layout,
+// a duration or as an uint64.
+func (c coinFlag) String() string {
+	return _CurrencyConvertor.ToCoinString(c.Amount)
+}
+
+// Set implements pflag.Value.Set,
+// which parses the given string either as a timestamp in DateOnlyLayout or RFC822 layout,
+// a duration or as an uint64.
+func (c *coinFlag) Set(s string) (err error) {
+	c.Amount, err = _CurrencyConvertor.ParseCoinString(s)
+	return
+}
+
+// Type implements pflag.Value.Type
+func (c coinFlag) Type() string {
+	return "Coin"
+}
+
+var (
+	_ pflag.Value = (*coinFlag)(nil)
+)

--- a/pkg/client/flag_test.go
+++ b/pkg/client/flag_test.go
@@ -1,0 +1,49 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/rivine/rivine/types"
+)
+
+func TestCoinFlag(t *testing.T) {
+	// test coin->string->coin->string
+	coins := []coinFlag{
+		coinFlag{},
+		coinFlag{types.NewCurrency64(1)},
+		coinFlag{types.NewCurrency64(42)},
+		coinFlag{types.NewCurrency64(1234567890123456789)},
+	}
+	for idx, coin := range coins {
+		str := coin.String()
+		err := coin.Set(str)
+		if err != nil {
+			t.Errorf("error while setting string for coin #%d: %v (input: '%s')", idx, err, str)
+		}
+		str2 := coin.String()
+		if str != str2 {
+			t.Errorf("coin #%d string loading isn't deterministic: %s != %s", idx, str, str2)
+		}
+	}
+
+	// test string->loader->string
+	testCases := []string{
+		"0.00001",
+		"1",
+		"0",
+		"123456",
+		"42",
+		"12345.67889",
+	}
+	for idx, testCase := range testCases {
+		var cf coinFlag
+		err := cf.Set(testCase)
+		if err != nil {
+			t.Errorf("error while loading string for coin flag #%d: %v", idx, err)
+		}
+		str := cf.String()
+		if testCase != str {
+			t.Errorf("coin flag #%d string loading isn't deterministic: %s != %s", idx, testCase, str)
+		}
+	}
+}

--- a/pkg/client/http.go
+++ b/pkg/client/http.go
@@ -11,6 +11,10 @@ import (
 	"github.com/rivine/rivine/api"
 )
 
+var (
+	errStatusNotFound = errors.New("expecting a response, but API returned status code 204 No Content")
+)
+
 // Non2xx returns true for non-success HTTP status codes.
 func Non2xx(code int) bool {
 	return code < 200 || code > 299
@@ -76,7 +80,7 @@ func (c *HTTPClient) GetAPI(call string, obj interface{}) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNoContent {
-		return errors.New("expecting a response, but API returned status code 204 No Content")
+		return errStatusNotFound
 	}
 
 	err = json.NewDecoder(resp.Body).Decode(obj)

--- a/types/transactions_test.go
+++ b/types/transactions_test.go
@@ -421,7 +421,7 @@ func TestTransactionEncodingDocExamples(t *testing.T) {
 					{
 						ParentID: CoinOutputID(hs("3300000000000000000000000000000000000000000000000000000000000033")),
 						Fulfillment: NewFulfillment(&anyAtomicSwapFulfillment{
-							MarshalableUnlockFulfillment: &AtomicSwapFulfillment{
+							atomicSwapFulfillment: &AtomicSwapFulfillment{
 								PublicKey: SiaPublicKey{
 									Algorithm: SignatureEd25519,
 									Key:       hbs("abababababababababababababababababababababababababababababababab"),
@@ -434,7 +434,7 @@ func TestTransactionEncodingDocExamples(t *testing.T) {
 					{
 						ParentID: CoinOutputID(hs("4400000000000000000000000000000000000000000000000000000000000044")),
 						Fulfillment: NewFulfillment(&anyAtomicSwapFulfillment{
-							MarshalableUnlockFulfillment: &LegacyAtomicSwapFulfillment{
+							atomicSwapFulfillment: &LegacyAtomicSwapFulfillment{
 								Sender: UnlockHash{
 									Type: UnlockTypePubKey,
 									Hash: hs("1234567891234567891234567891234567891234567891234567891234567891"),
@@ -1168,7 +1168,7 @@ func TestTransactionJSONEncodingExamples(t *testing.T) {
 					{
 						ParentID: CoinOutputID(hs("012345defabc012345defabc012345defabc012345defabc012345defabc0123")),
 						Fulfillment: NewFulfillment(&anyAtomicSwapFulfillment{
-							MarshalableUnlockFulfillment: &AtomicSwapFulfillment{
+							atomicSwapFulfillment: &AtomicSwapFulfillment{
 								PublicKey: SiaPublicKey{
 									Algorithm: SignatureEd25519,
 									Key:       hbs("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
@@ -1181,7 +1181,7 @@ func TestTransactionJSONEncodingExamples(t *testing.T) {
 					{
 						ParentID: CoinOutputID(hs("045645defabc012345defabc012345defabc012345defabc012345defabc0123")),
 						Fulfillment: NewFulfillment(&anyAtomicSwapFulfillment{
-							MarshalableUnlockFulfillment: &LegacyAtomicSwapFulfillment{
+							atomicSwapFulfillment: &LegacyAtomicSwapFulfillment{
 								Sender: UnlockHash{
 									Type: UnlockTypePubKey,
 									Hash: hs("654f96b317efe5fd6cd8ba1a394dce7b6ebe8c9621d6c44cbe3c8f1b58ce632a"),

--- a/types/unlockcondition.go
+++ b/types/unlockcondition.go
@@ -345,6 +345,10 @@ var (
 	// fulfillment is not allowed to unlock the input (as the associated pubkey hash is not
 	// listed in the conditions unlockhashes)
 	ErrUnauthorizedPubKey = errors.New("public key used which is not allowed to sign this input")
+
+	// ErrPrematureRefund is an error returned when a refund is requested for a contract,
+	// while the contract is still active, and thus not yet expired.
+	ErrPrematureRefund = errors.New("contract cannot yet be refunded")
 )
 
 // RegisterUnlockConditionType is used to register a condition type, by linking it to
@@ -793,24 +797,22 @@ func (ss *SingleSignatureFulfillment) Unmarshal(b []byte) error {
 func (as *AtomicSwapCondition) Fulfill(fulfillment UnlockFulfillment, ctx FulfillContext) error {
 	switch tf := fulfillment.(type) {
 	case *AtomicSwapFulfillment:
+		// An atomic swap c ontract can only be fulfilled in 1 of 2 ways:
+		//  1) By revealing the preimage (secret) for the secret hash /and/
+		//     a valid signature for the participator's address is provided
+		//  2) Once the timelock expires /and/
+		//     a valid signature for the initiator's address is provided.
+
 		// create the unlockHash for the given public Ke
 		unlockHash := NewUnlockHash(UnlockTypePubKey,
 			crypto.HashObject(encoding.Marshal(tf.PublicKey)))
-		// prior to our timelock, only the receiver can claim the unspend output
-		if ctx.BlockTime <= as.TimeLock {
-			// verify that receiver public key was given
+
+		// if secret is given, we'll assume that the participator (receiver) wants to claim
+		if tf.Secret != (AtomicSwapSecret{}) {
+			// verify that receiver's (participator) public key was given
 			if unlockHash.Cmp(as.Receiver) != 0 {
 				return ErrInvalidRedeemer
 			}
-
-			// verify signature
-			err := verifyHashUsingSiaPublicKey(
-				tf.PublicKey, ctx.InputIndex, ctx.Transaction, tf.Signature,
-				tf.PublicKey, tf.Secret)
-			if err != nil {
-				return err
-			}
-
 			// in order for the receiver to spend,
 			// the secret has to be known
 			hashedSecret := NewAtomicSwapHashedSecret(tf.Secret)
@@ -818,16 +820,24 @@ func (as *AtomicSwapCondition) Fulfill(fulfillment UnlockFulfillment, ctx Fulfil
 				return ErrInvalidPreImageSha256
 			}
 
-			return nil
+			// verify signature
+			return verifyHashUsingSiaPublicKey(
+				tf.PublicKey, ctx.InputIndex, ctx.Transaction, tf.Signature,
+				tf.PublicKey, tf.Secret)
 		}
 
-		// verify that sender public key was given
+		// if no secret is given, we'll assume that the initiator wants to refund,
+		// in which case we'll want to make sure the contract has expired,
+		// otherwise a refund is not (yet) possible
+		if ctx.BlockTime <= as.TimeLock {
+			return ErrPrematureRefund
+		}
+
+		// verify the given unlockhash is indeed the one of the inititiator (sender)
 		if unlockHash.Cmp(as.Sender) != 0 {
 			return ErrInvalidRedeemer
 		}
-
-		// after the deadline (timelock),
-		// only the original sender can reclaim the unspend output
+		// verify the signature is indeed done by
 		return verifyHashUsingSiaPublicKey(
 			tf.PublicKey, ctx.InputIndex, ctx.Transaction, tf.Signature,
 			tf.PublicKey)

--- a/types/unlockcondition.go
+++ b/types/unlockcondition.go
@@ -527,7 +527,11 @@ type (
 	// anyAtomicSwapFulfillment is used to be able to unmarshal an atomic swap fulfillment,
 	// no matter if it's in the legacy format or in the original format.
 	anyAtomicSwapFulfillment struct {
+		atomicSwapFulfillment
+	}
+	atomicSwapFulfillment interface {
 		MarshalableUnlockFulfillment
+		AtomicSwapSecret() AtomicSwapSecret
 	}
 )
 
@@ -687,7 +691,7 @@ func (uh *UnlockHashCondition) Fulfill(fulfillment UnlockFulfillment, ctx Fulfil
 			tf.PublicKey)
 
 	case *anyAtomicSwapFulfillment:
-		return uh.Fulfill(tf.MarshalableUnlockFulfillment, ctx)
+		return uh.Fulfill(tf.atomicSwapFulfillment, ctx)
 
 	default:
 		return ErrUnexpectedUnlockFulfillment
@@ -867,7 +871,7 @@ func (as *AtomicSwapCondition) Fulfill(fulfillment UnlockFulfillment, ctx Fulfil
 		}, ctx)
 
 	case *anyAtomicSwapFulfillment:
-		return as.Fulfill(tf.MarshalableUnlockFulfillment, ctx)
+		return as.Fulfill(tf.atomicSwapFulfillment, ctx)
 
 	default:
 		return ErrUnexpectedUnlockFulfillment
@@ -1237,14 +1241,14 @@ func (as *anyAtomicSwapFulfillment) Unmarshal(b []byte) error {
 	// be positive, first try the new format
 	err := encoding.Unmarshal(b, asf)
 	if err == nil {
-		as.MarshalableUnlockFulfillment = asf
+		as.atomicSwapFulfillment = asf
 		return nil
 	}
 
 	// didn't work out, let's try the legacy atomic swap fulfillment
 	lasf := new(LegacyAtomicSwapFulfillment)
 	err = encoding.Unmarshal(b, lasf)
-	as.MarshalableUnlockFulfillment = lasf
+	as.atomicSwapFulfillment = lasf
 	return err
 }
 
@@ -1255,7 +1259,7 @@ func (as *anyAtomicSwapFulfillment) Unmarshal(b []byte) error {
 // rather than as part of this in-memory structure,
 // as it is not supposed to be visible from an encoded perspective.
 func (as *anyAtomicSwapFulfillment) MarshalJSON() ([]byte, error) {
-	return json.Marshal(as.MarshalableUnlockFulfillment)
+	return json.Marshal(as.atomicSwapFulfillment)
 }
 
 // UnmarshalJSON implements json.Unmarshaler.UnmarshalJSON
@@ -1286,9 +1290,9 @@ func (as *anyAtomicSwapFulfillment) UnmarshalJSON(b []byte) error {
 	}
 	switch undefOptArgCount {
 	case 0:
-		as.MarshalableUnlockFulfillment = lasf
+		as.atomicSwapFulfillment = lasf
 	case 4:
-		as.MarshalableUnlockFulfillment = &AtomicSwapFulfillment{
+		as.atomicSwapFulfillment = &AtomicSwapFulfillment{
 			PublicKey: lasf.PublicKey,
 			Signature: lasf.Signature,
 			Secret:    lasf.Secret,

--- a/types/unlockcondition_test.go
+++ b/types/unlockcondition_test.go
@@ -1774,6 +1774,22 @@ func TestValidFulFill(t *testing.T) {
 			},
 			sk,
 		},
+		{ // atomic swap -> atomic swap (claim, possible even when expired)
+			&AtomicSwapCondition{
+				Receiver:     NewUnlockHash(UnlockTypePubKey, crypto.HashObject(encoding.Marshal(ed25519pk))),
+				Sender:       unlockHashFromHex("01437c56286c76dec14e87f5da5e5a436651006e6cd46bee5865c9060ba178f7296ed843b70a57"),
+				HashedSecret: NewAtomicSwapHashedSecret(AtomicSwapSecret{4, 2}),
+				TimeLock:     42,
+			},
+			func() MarshalableUnlockFulfillment {
+				return &AtomicSwapFulfillment{
+					PublicKey: ed25519pk,
+					Secret:    AtomicSwapSecret{4, 2},
+					// Signature is set at signing step
+				}
+			},
+			sk,
+		},
 		{ // atomic swap -> atomic swap (refund)
 			&AtomicSwapCondition{
 				Sender:       NewUnlockHash(UnlockTypePubKey, crypto.HashObject(encoding.Marshal(ed25519pk))),


### PR DESCRIPTION
+ only check timelock for atomic swap refunds (fixes #351, fixes threefoldfoundation/tfchain#112)
+ align atomic swap cli commands terminology (fixes #334):
  + rename atomicswap claim to atomicswap redeem (fixes #347);
   + remove amount parameter in redeem/refund commands (fixes #348);
   + align the audit command where possible;
   + change help to update terminology;
   + change hashed secret to secret hash;
   + rename atomicswap audit to atomicswap auditcontract;
   + rename sender to initiator;
   + rename receiver to participator;
+ fix bugs in atomic swap commands:
   + ensure secret can be extracted from atomic swap secret (fixes threefoldfoundation/tfchain#116);

Atomic Swap commands usage and help now is as follows:

```
Usage:
  rivinec atomicswap [command]

Available Commands:
  auditcontract Audit a created atomic swap contract.
  extractsecret Extract the secret from a redeemed swap contract.
  initiate      Create an atomic swap contract as initiator.
  participate   Create an atomic swap contract as participant.
  redeem        Redeem the coins locked in an atomic swap contract.
  refund        Refund the coins locked in an atomic swap contract.
```

usage summary:

```
initiate <participant address> <amount> [flags]
participate <initiator address> <amount> <secret hash> [flags]
auditcontract outputid [flags]
redeem outputid secret [flags]
refund outputid [flags]
extractsecret transactionid [outputid] [flags]
```

`initiate` command usage and help is now as follows:

```
Create an atomic swap contract as an initiator,
such that you can share its public information with the participant.

Usage:
  rivinec atomicswap initiate <participant address> <amount> [flags]

Flags:
  -d, --duration duration        the duration of the atomic swap contract, the amount of time the participator has to collect (default 48h0m0s)
  -h, --help                     help for initiate
      --initiator StringLoader   optionally define a wallet address (unlockhash) that is to be used for refunding purposes, one will be generated for you if none is given
```

`participate` command usage and help is now as follows:

```
Create an atomic swap contract as a participant,
using the secret hash given by the initiator.

Usage:
  rivinec atomicswap participate <initiator address> <amount> <secret hash> [flags]

Flags:
  -d, --duration duration        the duration of the atomic swap contract, the amount of time the participator has to collect (default 24h0m0s)
  -h, --help                     help for participate
      --initiator StringLoader   optionally define a wallet address (unlockhash) that is to be used for refunding purposes, one will be generated for you if none is given
```

`auditcontract` command usage and help is now as follows:

```
Audit a created atomic swap contract.

It will try to look for the given outputid in the consensus as an unspent coin output.
Should it not be find as an unspent output it will try to look in the transaction pool
as to confirm it might be not part of a created block yet.

Optionally the participant's address, currency amount and secret hash can be validated,
by giving one, some or all of them as flag arguments.

Should an unspent atomic swap contract be found, it will be printed to the STDOUT formatted
in a human-optimized format.

Usage:
  rivinec atomicswap auditcontract outputid [flags]

Flags:
      --amount Coin                 optionally validate the given coin amount to the one found in the unspent coin output
  -h, --help                        help for auditcontract
      --min-duration duration       optionally validate the given contract has sufficient duration left, as defined by the timelock in the found atomic swap contract condition
      --participator StringLoader   optionally validate the given participator's address (unlockhash) to the one found in the atomic swap contract condition
      --secrethash StringLoader     optionally validate the expected secret hash to the secret hash of the found atomic swap contract condition (default 0000000000000000000000000000000000000000000000000000000000000000)
```

`redeem` command usage and help is now as follows:

```
Redeem the coins locked in an atomic swap contract intended for you.

Usage:
  rivinec atomicswap redeem outputid secret [flags]

Flags:
  -h, --help   help for redeem
```

`refund` command usage and help is now as follows:

```
Refund the coins locked in an atomic swap contract created by you.

Usage:
  rivinec atomicswap refund outputid [flags]

Flags:
  -h, --help   help for refund
```

`extractsecret` command usage and help is now as follows:

```
Extract the secret from a redeemed atomic swap contract.

It will look for a transaction in the consensus set, using the given transactionID.
The transaction should contain at least one atomic swap contract fulfillment.
If an outputID is given, the (coin) input, from which the secret is to be extracted,
has to have the given outputID as parent ID, otherwise the first input is used,
which has an atomic swap contract fulfillment.

If it was spend as a refund, than no secret can be extracted.

Optionally the expected hashedsecret can be given (as a flag), as to ensure that the
secret hash is as expected, and also matches the found/extracted secret.

Usage:
  rivinec atomicswap extractsecret transactionid [outputid] [flags]

Flags:
  -h, --help                      help for extractsecret
      --secrethash StringLoader   optionally validate the given secret hash with the secret hash of the found atomic swap contract condition (default 0000000000000000000000000000000000000000000000000000000000000000)
```
