### PR TITLE
Add support for multisig in transaction and output list

### DIFF
--- a/modules/wallet/outputs.go
+++ b/modules/wallet/outputs.go
@@ -19,7 +19,20 @@ func (w *Wallet) UnlockedUnspendOutputs() (map[types.CoinOutputID]types.CoinOutp
 			ucom[id] = co
 		}
 	}
+	// same for multisig
+	for id, co := range w.multiSigCoinOutputs {
+		if co.Condition.Fulfillable(ctx) {
+			ucom[id] = co
+		}
+	}
+	// block stakes
 	for id, bso := range w.blockstakeOutputs {
+		if bso.Condition.Fulfillable(ctx) {
+			ubsom[id] = bso
+		}
+	}
+	// block stake multisigs
+	for id, bso := range w.multiSigBlockStakeOutputs {
 		if bso.Condition.Fulfillable(ctx) {
 			ubsom[id] = bso
 		}
@@ -44,7 +57,20 @@ func (w *Wallet) LockedUnspendOutputs() (map[types.CoinOutputID]types.CoinOutput
 			ucom[id] = co
 		}
 	}
+	// same for multisig
+	for id, co := range w.multiSigCoinOutputs {
+		if !co.Condition.Fulfillable(ctx) {
+			ucom[id] = co
+		}
+	}
+	// block stakes
 	for id, bso := range w.blockstakeOutputs {
+		if !bso.Condition.Fulfillable(ctx) {
+			ubsom[id] = bso
+		}
+	}
+	// block stake multisigs
+	for id, bso := range w.multiSigBlockStakeOutputs {
 		if !bso.Condition.Fulfillable(ctx) {
 			ubsom[id] = bso
 		}

--- a/modules/wallet/update.go
+++ b/modules/wallet/update.go
@@ -191,6 +191,13 @@ func (w *Wallet) applyHistory(cc modules.ConsensusChange) {
 				_, exists := w.keys[sci.Fulfillment.UnlockHash()]
 				if exists {
 					relevant = true
+				} else if _, exists = w.multiSigCoinOutputs[sci.ParentID]; exists {
+					// Since we know about every multisig output that is still open and releated,
+					// any relevant multisig input must have a parent ID present in the multisig
+					// output map.
+					relevant = true
+					// set "exists" to false since the output is not owned by the wallet.
+					exists = false
 				}
 				pt.Inputs = append(pt.Inputs, modules.ProcessedInput{
 					FundType:       types.SpecifierCoinInput,
@@ -203,6 +210,12 @@ func (w *Wallet) applyHistory(cc modules.ConsensusChange) {
 				_, exists := w.keys[sco.Condition.UnlockHash()]
 				if exists {
 					relevant = true
+				} else if _, exists = w.multiSigCoinOutputs[txn.CoinOutputID(uint64(i))]; exists {
+					// If the coin ouput is a relevant multisig output, it's ID will already
+					// be present in the multisigCoinOutputs map
+					relevant = true
+					// set "exists" to false since the output is not owned by the wallet.
+					exists = false
 				}
 				pt.Outputs = append(pt.Outputs, modules.ProcessedOutput{
 					FundType:       types.SpecifierCoinOutput,
@@ -217,6 +230,13 @@ func (w *Wallet) applyHistory(cc modules.ConsensusChange) {
 				_, exists := w.keys[sfi.Fulfillment.UnlockHash()]
 				if exists {
 					relevant = true
+				} else if _, exists = w.multiSigBlockStakeOutputs[sfi.ParentID]; exists {
+					// Since we know about every multisig output that is still open and releated,
+					// any relevant multisig input must have a parent ID present in the multisig
+					// output map.
+					relevant = true
+					// set "exists" to false since the output is not owned by the wallet.
+					exists = false
 				}
 				sfiValue := w.historicOutputs[types.OutputID(sfi.ParentID)]
 				pt.Inputs = append(pt.Inputs, modules.ProcessedInput{
@@ -230,6 +250,12 @@ func (w *Wallet) applyHistory(cc modules.ConsensusChange) {
 				_, exists := w.keys[sfo.Condition.UnlockHash()]
 				if exists {
 					relevant = true
+				} else if _, exists = w.multiSigBlockStakeOutputs[txn.BlockStakeOutputID(uint64(i))]; exists {
+					// If the block stake output is a relevant multisig output, it's ID will already
+					// be present in the multisigBlockStakeOutputs map
+					relevant = true
+					// set "exists" to false since the output is not owned by the wallet.
+					exists = false
 				}
 				pt.Outputs = append(pt.Outputs, modules.ProcessedOutput{
 					FundType:       types.SpecifierBlockStakeOutput,
@@ -312,6 +338,13 @@ func (w *Wallet) ReceiveUpdatedUnconfirmedTransactions(txns []types.Transaction,
 			_, exists := w.keys[sci.Fulfillment.UnlockHash()]
 			if exists {
 				relevant = true
+			} else if _, exists = w.multiSigCoinOutputs[sci.ParentID]; exists {
+				// Since we know about every multisig output that is still open and releated,
+				// any relevant multisig input must have a parent ID present in the multisig
+				// output map.
+				relevant = true
+				// set "exists" to false since the output is not owned by the wallet.
+				exists = false
 			}
 			pt.Inputs = append(pt.Inputs, modules.ProcessedInput{
 				FundType:       types.SpecifierCoinInput,
@@ -324,6 +357,12 @@ func (w *Wallet) ReceiveUpdatedUnconfirmedTransactions(txns []types.Transaction,
 			_, exists := w.keys[sco.Condition.UnlockHash()]
 			if exists {
 				relevant = true
+			} else if _, exists = w.multiSigCoinOutputs[txn.CoinOutputID(uint64(i))]; exists {
+				// If the coin ouput is a relevant multisig output, it's ID will already
+				// be present in the multisigCoinOutputs map
+				relevant = true
+				// set "exists" to false since the output is not owned by the wallet.
+				exists = false
 			}
 			pt.Outputs = append(pt.Outputs, modules.ProcessedOutput{
 				FundType:       types.SpecifierCoinOutput,


### PR DESCRIPTION
Add support for multisig input and outputs when listing transaction and (un)locked outputs
Fix #356 
Fix #358 