### PR TITLE
improve strictness of consensus and demote legacy transactions

### DIFF
--- a/modules/consensus/diffs.go
+++ b/modules/consensus/diffs.go
@@ -6,6 +6,7 @@ import (
 	"github.com/rivine/rivine/build"
 	"github.com/rivine/rivine/encoding"
 	"github.com/rivine/rivine/modules"
+	"github.com/rivine/rivine/types"
 
 	"github.com/rivine/bbolt"
 )
@@ -156,7 +157,11 @@ func (cs *ConsensusSet) generateAndApplyDiff(tx *bolt.Tx, pb *processedBlock) er
 	// validated all at once because some transactions may not be valid until
 	// previous transactions have been applied.
 	for _, txn := range pb.Block.Transactions {
-		err := validTransaction(tx, txn, cs.chainCts.BlockSizeLimit, cs.chainCts.ArbitraryDataSizeLimit, pb.Height, pb.Block.Timestamp)
+		err := validTransaction(tx, txn, types.TransactionValidationConstants{
+			BlockSizeLimit:         cs.chainCts.BlockSizeLimit,
+			ArbitraryDataSizeLimit: cs.chainCts.ArbitraryDataSizeLimit,
+			MinimumMinerFee:        cs.chainCts.MinimumTransactionFee,
+		}, pb.Height, pb.Block.Timestamp)
 		if err != nil {
 			return err
 		}

--- a/modules/transactionpool.go
+++ b/modules/transactionpool.go
@@ -7,17 +7,6 @@ import (
 	"github.com/rivine/rivine/types"
 )
 
-const (
-	// TransactionSizeLimit defines the size of the largest transaction that
-	// will be accepted by the transaction pool according to the IsStandard
-	// rules.
-	TransactionSizeLimit = 16e3
-
-	// TransactionSetSizeLimit defines the largest set of dependent unconfirmed
-	// transactions that will be accepted by the transaction pool.
-	TransactionSetSizeLimit = 250e3
-)
-
 var (
 	// ErrDuplicateTransactionSet is the error that gets returned if a
 	// duplicate transaction set is given to the transaction pool.
@@ -74,10 +63,6 @@ type TransactionPool interface {
 	// within one block. The minimum has a strong chance of getting accepted
 	// within 10 blocks.
 	FeeEstimation() (minimumRecommended, maximumRecommended types.Currency)
-
-	// IsStandardTransaction returns `err = nil` if the transaction is
-	// standard, otherwise it returns an error explaining what is not standard.
-	IsStandardTransaction(types.Transaction) error
 
 	// PurgeTransactionPool is a temporary function available to the miner. In
 	// the event that a miner mines an unacceptable block, the transaction pool

--- a/modules/transactionpool/accept.go
+++ b/modules/transactionpool/accept.go
@@ -14,21 +14,9 @@ import (
 	"github.com/rivine/bbolt"
 )
 
-const (
-	// The TransactionPoolSizeLimit is first checked, and then a transaction
-	// set is added. The current transaction pool does not do any priority
-	// ordering, so the size limit is such that the transaction pool will never
-	// exceed the size of a block.
-	//
-	// TODO: Add a priority structure that will allow the transaction pool to
-	// fill up beyond the size of a single block, without being subject to
-	// manipulation.
-	//
-	// The first ~1/4 of the transaction pool can be filled for free. This is
-	// mostly to preserve compatibility with clients that do not add fees.
-	TransactionPoolSizeLimit  = 2e6 - 5e3 - modules.TransactionSetSizeLimit
-	TransactionPoolSizeForFee = 500e3
-)
+// TODO: Add a priority structure that will allow the transaction pool to
+// fill up beyond the size of a single block, without being subject to
+// manipulation.
 
 var (
 	errObjectConflict      = errors.New("transaction set conflicts with an existing transaction set")
@@ -62,29 +50,9 @@ func relatedObjectIDs(ts []types.Transaction) []ObjectID {
 	return oids
 }
 
-// checkMinerFees checks that the total amount of transaction fees in the
-// transaction set is sufficient to earn a spot in the transaction pool.
-func (tp *TransactionPool) checkMinerFees(ts []types.Transaction) error {
-	// Currently required fees are set on a per-transaction basis.
-	// At least the minimum Fee per transaction is required,
-	// more is allowed, but not less.
-	for _, t := range ts {
-		var feeSum types.Currency
-		for _, fee := range t.MinerFees {
-			feeSum = feeSum.Add(fee)
-		}
-		if feeSum.Cmp(tp.chainCts.MinimumTransactionFee) == -1 {
-			return errLowMinerFees
-		}
-	}
-	return nil
-}
-
-// checkTransactionSetComposition checks if the transaction set is valid given
-// the state of the pool. It does not check that each individual transaction
-// would be legal in the next block, but does check things like miner fees and
-// IsStandard.
-func (tp *TransactionPool) checkTransactionSetComposition(ts []types.Transaction) error {
+// validateTransactionSetComposition checks if the transaction set
+// is valid given the state of the pool.
+func (tp *TransactionPool) validateTransactionSetComposition(ts []types.Transaction) error {
 	// Check that the transaction set is not already known.
 	setID := TransactionSetID(crypto.HashObject(ts))
 	_, exists := tp.transactionSets[setID]
@@ -92,25 +60,22 @@ func (tp *TransactionPool) checkTransactionSetComposition(ts []types.Transaction
 		return modules.ErrDuplicateTransactionSet
 	}
 
-	if tp.transactionListSize > TransactionPoolSizeLimit {
+	if tp.transactionListSize > tp.chainCts.TransactionPool.PoolSizeLimit {
 		return errFullTransactionPool
 	}
 
-	// Check that the transaction set has enough fees to justify adding it to
-	// the transaction list.
-	err := tp.checkMinerFees(ts)
-	if err != nil {
-		return err
-	}
-
-	// All checks after this are expensive.
-	//
 	// TODO: There is no DoS prevention mechanism in place to prevent repeated
 	// expensive verifications of invalid transactions that are created on the
 	// fly.
 
-	// Check that all transactions follow 'Standard.md' guidelines.
-	err = tp.IsStandardTransactionSet(ts)
+	// Validates that the transaction set fits within the
+	// chain (network) defined byte size limit, when binary encoded.
+	// It also validates that the the transaction itself does not exceed a transaction pool defined
+	// network (chain) constant, again on a byte level. On top of these transaction pool specific rules,
+	// it also validates that the transaction is valid according to the consensus,
+	// meaning all properties are standard, known and valid. It does however check this within the context
+	// that the validation code knows the transaction is still unconfirmed, and thus not yet part of a created block.
+	err := tp.ValidateTransactionSet(ts)
 	if err != nil {
 		return err
 	}
@@ -178,9 +143,9 @@ func (tp *TransactionPool) handleConflicts(ts []types.Transaction, conflicts []T
 	}
 	superset = append(superset, dedupSet...)
 
-	// Check the composition of the transaction set, including fees and
+	// Validates the composition of the transaction set, including fees and
 	// IsStandard rules (this is a new set, the rules must be rechecked).
-	err := tp.checkTransactionSetComposition(superset)
+	err := tp.validateTransactionSetComposition(superset)
 	if err != nil {
 		return err
 	}
@@ -240,9 +205,8 @@ func (tp *TransactionPool) acceptTransactionSet(ts []types.Transaction) error {
 		return modules.ErrDuplicateTransactionSet
 	}
 
-	// Check the composition of the transaction set, including fees and
-	// IsStandard rules.
-	err = tp.checkTransactionSetComposition(ts)
+	// Validate the composition of the transaction set
+	err = tp.validateTransactionSetComposition(ts)
 	if err != nil {
 		return err
 	}

--- a/modules/transactionpool/standard.go
+++ b/modules/transactionpool/standard.go
@@ -6,84 +6,35 @@ import (
 	"github.com/rivine/rivine/types"
 )
 
-// standard.go adds extra rules to transactions which help preserve network
-// health and provides flexibility for future soft forks and tweaks to the
-// network.
-//
-// Rule: Transaction size is limited
-//		There is a DoS vector where large transactions can both contain many
-//		signatures, and have each signature's CoveredFields object cover a
-//		unique but large portion of the transaction. A 1mb transaction could
-//		force a verifier to hash very large volumes of data, which takes a long
-//		time on nonspecialized hardware.
-//
-// Rule: Foreign signature algorithms are rejected.
-//		There are plans to add newer, faster signature algorithms to Sia as the
-//		project matures and the need for increased verification speed grows.
-//		Foreign signatures are allowed into the blockchain, where they are
-//		accepted as valid. Hoewver, if there has been a soft-fork, the foreign
-//		signatures might actually be invalid. This rule protects legacy miners
-//		from including potentially invalid transactions in their blocks.
-//
-// Rule: The types of allowed arbitrary data are limited
-//		The arbitrary data field can be used to orchestrate soft-forks to Sia
-//		that add features. Legacy miners are at risk of creating invalid blocks
-//		if they include arbitrary data which has meanings that the legacy miner
-//		doesn't understand.
-//
-// Rule: The transaction set size is limited.
-//		A group of dependent transactions cannot exceed 100kb to limit how
-//		quickly the transaction pool can be filled with new transactions.
-
-// IsStandardTransaction enforces extra rules such as a transaction size limit.
-// These rules can be altered without disrupting consensus.
-func (tp *TransactionPool) IsStandardTransaction(t types.Transaction) error {
-	// check if the transaction is valid/standard (e.g. based on its version)
-	err := t.ValidateTransaction(types.ValidationContext{
+// ValidateTransactionSet validates that all transacitons of a set follow the
+// defined standards and are valid within its local context, knowing the height and timestamp of the last block.
+// It also ensures that the transaction as well as the transaction set,
+// are within an acceptable byte size range, when binary encoded.
+func (tp *TransactionPool) ValidateTransactionSet(ts []types.Transaction) error {
+	totalSize := 0
+	ctx := types.ValidationContext{
 		Confirmed:   false,
 		BlockHeight: tp.consensusSet.Height(),
-	}, types.TransactionValidationConstants{
-		BlockSizeLimit:         tp.chainCts.BlockSizeLimit,
-		ArbitraryDataSizeLimit: tp.chainCts.ArbitraryDataSizeLimit,
-		MinimumMinerFee:        tp.chainCts.MinimumTransactionFee,
-	})
-	if err != nil {
-		return err
 	}
-
-	// Check that the size of the transaction does not exceed the standard
-	// established in Standard.md. Larger transactions are a DOS vector,
-	// because someone can fill a large transaction with a bunch of signatures
-	// that require hashing the entire transaction. Several hundred megabytes
-	// of hashing can be required of a verifier. Enforcing this rule makes it
-	// more difficult for attackers to exploid this DOS vector, though a miner
-	// with sufficient power could still create unfriendly blocks.
-	if len(encoding.Marshal(t)) > modules.TransactionSizeLimit {
-		return modules.ErrLargeTransaction
-	}
-
-	return nil
-}
-
-// IsStandardTransactionSet checks that all transacitons of a set follow the
-// IsStandard guidelines, and that the set as a whole follows the guidelines as
-// well.
-func (tp *TransactionPool) IsStandardTransactionSet(ts []types.Transaction) error {
-	// Check that the set is a reasonable size.
-	totalSize := 0
-	for i := range ts {
-		totalSize += len(encoding.Marshal(ts[i]))
-		if totalSize > modules.TransactionSetSizeLimit {
-			return modules.ErrLargeTransactionSet
+	//validate each transaction in the transaction set
+	var err error
+	for _, t := range ts {
+		size := len(encoding.Marshal(t))
+		if size > tp.chainCts.TransactionPool.TransactionSizeLimit {
+			return modules.ErrLargeTransaction
 		}
-	}
-
-	// Check that each transaction is acceptable.
-	for i := range ts {
-		err := tp.IsStandardTransaction(ts[i])
+		totalSize += size
+		err = t.ValidateTransaction(ctx, types.TransactionValidationConstants{
+			BlockSizeLimit:         tp.chainCts.BlockSizeLimit,
+			ArbitraryDataSizeLimit: tp.chainCts.ArbitraryDataSizeLimit,
+			MinimumMinerFee:        tp.chainCts.MinimumTransactionFee,
+		})
 		if err != nil {
 			return err
 		}
+	}
+	if totalSize > tp.chainCts.TransactionPool.TransactionSetSizeLimit {
+		return modules.ErrLargeTransactionSet
 	}
 	return nil
 }

--- a/types/constants.go
+++ b/types/constants.go
@@ -90,6 +90,8 @@ type ChainConstants struct {
 	DefaultTransactionVersion TransactionVersion
 
 	CurrencyUnits CurrencyUnits
+
+	TransactionPool TransactionPoolConstants
 }
 
 // CurrencyUnits defines the units used for the different kind of currencies.
@@ -98,10 +100,37 @@ type CurrencyUnits struct {
 	OneCoin Currency
 }
 
+// TransactionPoolConstants defines the constants used by the TransactionPool.
+type TransactionPoolConstants struct {
+	// TransactionSizeLimit defines the size of the largest transaction that
+	// will be accepted by the transaction pool according to the IsStandard
+	// rules.
+	TransactionSizeLimit int
+
+	// TransactionSetSizeLimit defines the largest set of dependent unconfirmed
+	// transactions that will be accepted by the transaction pool.
+	TransactionSetSizeLimit int
+
+	// The TransactionPoolSizeLimit is first checked, and then a transaction
+	// set is added. The current transaction pool does not do any priority
+	// ordering, so the size limit is such that the transaction pool will never
+	// exceed the size of a block.
+	PoolSizeLimit int
+}
+
 // DefaultCurrencyUnits provides sane defaults for currency units
 func DefaultCurrencyUnits() CurrencyUnits {
 	return CurrencyUnits{
 		OneCoin: NewCurrency(new(big.Int).Exp(big.NewInt(10), big.NewInt(9), nil)),
+	}
+}
+
+// DefaultTransactionPoolConstants provides sane defaults for TransactionPool constants.
+func DefaultTransactionPoolConstants() TransactionPoolConstants {
+	return TransactionPoolConstants{
+		TransactionSizeLimit:    16e3,
+		TransactionSetSizeLimit: 250e3,
+		PoolSizeLimit:           2e6 - 5e3 - 250e3,
 	}
 }
 
@@ -149,10 +178,11 @@ func DefaultChainConstants() ChainConstants {
 			StakeModifierDelay: 2000,
 			// Block stake aging if unspent block stake is not at index 0
 			BlockStakeAging:           uint64(1 << 10),
-			CurrencyUnits:             currencyUnits,
 			GenesisTransactionVersion: genesisTxnVersion,
 			DefaultTransactionVersion: defaultTxnVersion,
 			GenesisTimestamp:          Timestamp(1424139000),
+			CurrencyUnits:             currencyUnits,
+			TransactionPool:           DefaultTransactionPoolConstants(),
 		}
 		// Seed for the address given below twice:
 		// carbon boss inject cover mountain fetch fiber fit tornado cloth wing dinosaur proof joy intact fabric thumb rebel borrow poet chair network expire else
@@ -188,7 +218,6 @@ func DefaultChainConstants() ChainConstants {
 			ExtremeFutureThreshold:    6, // seconds
 			StakeModifierDelay:        20,
 			BlockStakeAging:           uint64(1 << 10),
-			CurrencyUnits:             currencyUnits,
 			GenesisTransactionVersion: genesisTxnVersion,
 			DefaultTransactionVersion: defaultTxnVersion,
 			GenesisBlockStakeAllocation: []BlockStakeOutput{
@@ -220,6 +249,8 @@ func DefaultChainConstants() ChainConstants {
 					})),
 				},
 			},
+			CurrencyUnits:   currencyUnits,
+			TransactionPool: DefaultTransactionPoolConstants(),
 		}
 	}
 
@@ -240,10 +271,11 @@ func DefaultChainConstants() ChainConstants {
 		ExtremeFutureThreshold:    5 * 60 * 60, // 5 hours.
 		StakeModifierDelay:        2000,
 		BlockStakeAging:           1 << 17, // 2^16s < 1 day < 2^17s
-		CurrencyUnits:             currencyUnits,
 		GenesisTimestamp:          Timestamp(1496322000),
 		GenesisTransactionVersion: genesisTxnVersion,
 		DefaultTransactionVersion: defaultTxnVersion,
+		CurrencyUnits:             currencyUnits,
+		TransactionPool:           DefaultTransactionPoolConstants(),
 	}
 
 	cts.GenesisBlockStakeAllocation = append(cts.GenesisBlockStakeAllocation, BlockStakeOutput{

--- a/types/signatures.go
+++ b/types/signatures.go
@@ -190,29 +190,6 @@ func sortedUnique(elems []uint64, max int) bool {
 	return true
 }
 
-// validateNoDoubleSpends validates that no output has been spend twice.
-func (t *Transaction) validateNoDoubleSpends() (err error) {
-	spendCoins := make(map[CoinOutputID]struct{})
-	for _, ci := range t.CoinInputs {
-		if _, found := spendCoins[ci.ParentID]; found {
-			err = ErrDoubleSpend
-			return
-		}
-		spendCoins[ci.ParentID] = struct{}{}
-	}
-
-	spendBlockStakes := make(map[BlockStakeOutputID]struct{})
-	for _, bsi := range t.BlockStakeInputs {
-		if _, found := spendBlockStakes[bsi.ParentID]; found {
-			err = ErrDoubleSpend
-			return
-		}
-		spendBlockStakes[bsi.ParentID] = struct{}{}
-	}
-
-	return
-}
-
 // LoadString is the inverse of SiaPublicKey.String().
 func (spk *SiaPublicKey) LoadString(s string) error {
 	parts := strings.SplitN(s, ":", 2)

--- a/types/signatures_test.go
+++ b/types/signatures_test.go
@@ -33,8 +33,7 @@ func TestSigHash(t *testing.T) {
 		MinerFees:         []Currency{{}},
 		ArbitraryData:     []byte{'o', 't'},
 	}
-
-	_ = txn.InputSigHash(0)
+	txn.InputSigHash(0)
 }
 
 // TestSortedUnique probes the sortedUnique function.

--- a/types/transaction_legacy_test.go
+++ b/types/transaction_legacy_test.go
@@ -94,8 +94,8 @@ func TestLegacyTransactionInputLockProxyJSONEncoding(t *testing.T) {
 
 func TestLegacyTransactionBinaryEncoding(t *testing.T) {
 	testCases := []string{
-		`0001000000000000002200000000000000000000000000000000000000000000000000000000000022013800000000000000656432353531390000000000000000002000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff4000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000000000000000000000000000000000000000000000001000000000000000100000000000000010000000000000000`,
-		`0002000000000000002200000000000000000000000000000000000000000000000000000000000022013800000000000000656432353531390000000000000000002000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff4000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3300000000000000000000000000000000000000000000000000000000000033026a00000000000000011234567891234567891234567891234567891234567891234567891234567891016363636363636363636363636363636363636363636363636363636363636363bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb07edb85a00000000a000000000000000656432353531390000000000000000002000000000000000abababababababababababababababababababababababababababababababab4000000000000000dededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededabadabadabadabadabadabadabadabadabadabadabadabadabadabadabadaba020000000000000001000000000000000201cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc01000000000000000302dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd01000000000000004400000000000000000000000000000000000000000000000000000000000044013800000000000000656432353531390000000000000000002000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee4000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee010000000000000001000000000000002a01abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd010000000000000001000000000000000102000000000000003432`,
+		`01000000000000002200000000000000000000000000000000000000000000000000000000000022013800000000000000656432353531390000000000000000002000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff4000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000000000000000000000000000000000000000000000001000000000000000100000000000000010000000000000000`,
+		`02000000000000002200000000000000000000000000000000000000000000000000000000000022013800000000000000656432353531390000000000000000002000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff4000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3300000000000000000000000000000000000000000000000000000000000033026a00000000000000011234567891234567891234567891234567891234567891234567891234567891016363636363636363636363636363636363636363636363636363636363636363bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb07edb85a00000000a000000000000000656432353531390000000000000000002000000000000000abababababababababababababababababababababababababababababababab4000000000000000dededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededabadabadabadabadabadabadabadabadabadabadabadabadabadabadabadaba020000000000000001000000000000000201cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc01000000000000000302dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd01000000000000004400000000000000000000000000000000000000000000000000000000000044013800000000000000656432353531390000000000000000002000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee4000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee010000000000000001000000000000002a01abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd010000000000000001000000000000000102000000000000003432`,
 	}
 	for testIndex, testCase := range testCases {
 		binaryInput, err := hex.DecodeString(testCase)
@@ -104,13 +104,13 @@ func TestLegacyTransactionBinaryEncoding(t *testing.T) {
 			continue
 		}
 
-		var txn legacyTransaction
-		err = encoding.Unmarshal(binaryInput, &txn)
+		var ltd legacyTransactionData
+		err = encoding.Unmarshal(binaryInput, &ltd)
 		if err != nil {
 			t.Error(testIndex, err)
 			continue
 		}
-		b := encoding.Marshal(txn)
+		b := encoding.Marshal(ltd)
 
 		output := hex.EncodeToString(b)
 		if output != testCase {
@@ -122,111 +122,105 @@ func TestLegacyTransactionBinaryEncoding(t *testing.T) {
 func TestLegacyTransactionJSONEncoding(t *testing.T) {
 	testCases := []string{
 		`{
-	"version": 0,
-	"data": {
-		"coininputs": [
-			{
-				"parentid": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-				"unlocker": {
-					"type": 1,
-					"condition": {
-						"publickey": "ed25519:def123def123def123def123def123def123def123def123def123def123def1"
-					},
-					"fulfillment": {
-						"signature": "ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef"
-					}
+	"coininputs": [
+		{
+			"parentid": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			"unlocker": {
+				"type": 1,
+				"condition": {
+					"publickey": "ed25519:def123def123def123def123def123def123def123def123def123def123def1"
+				},
+				"fulfillment": {
+					"signature": "ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef12345ef"
 				}
 			}
-		],
-		"minerfees": [
-			"1"
-		],
-		"arbitrarydata": "SGVsbG8sIFdvcmxkIQ=="
-	}
+		}
+	],
+	"minerfees": [
+		"1"
+	],
+	"arbitrarydata": "SGVsbG8sIFdvcmxkIQ=="
 }`, `{
-	"version": 0,
-	"data": {
-		"coininputs": [
-			{
-				"parentid": "abcdef012345abcdef012345abcdef012345abcdef012345abcdef012345abcd",
-				"unlocker": {
-					"type": 1,
-					"condition": {
-						"publickey": "ed25519:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-					},
-					"fulfillment": {
-						"signature": "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefab"
-					}
-				}
-			},
-			{
-				"parentid": "012345defabc012345defabc012345defabc012345defabc012345defabc0123",
-				"unlocker": {
-					"type": 2,
-					"condition": {
-						"sender": "01654f96b317efe5fd6cd8ba1a394dce7b6ebe8c9621d6c44cbe3c8f1b58ce632a3216de71b23b",
-						"receiver": "01e89843e4b8231a01ba18b254d530110364432aafab8206bea72e5a20eaa55f70b1ccc65e2105",
-						"hashedsecret": "abc543defabc543defabc543defabc543defabc543defabc543defabc543defa",
-						"timelock": 1522068743
-					},
-					"fulfillment": {
-						"publickey": "ed25519:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-						"signature": "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefab",
-						"secret": "def789def789def789def789def789dedef789def789def789def789def789de"
-					}
+	"coininputs": [
+		{
+			"parentid": "abcdef012345abcdef012345abcdef012345abcdef012345abcdef012345abcd",
+			"unlocker": {
+				"type": 1,
+				"condition": {
+					"publickey": "ed25519:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+				},
+				"fulfillment": {
+					"signature": "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefab"
 				}
 			}
-		],
-		"coinoutputs": [
-			{
-				"value": "3",
-				"unlockhash": "0142e9458e348598111b0bc19bda18e45835605db9f4620616d752220ae8605ce0df815fd7570e"
-			},
-			{
-				"value": "5",
-				"unlockhash": "01a6a6c5584b2bfbd08738996cd7930831f958b9a5ed1595525236e861c1a0dc353bdcf54be7d8"
-			},
-			{
-				"value": "8",
-				"unlockhash": "02a24c97c80eeac111aa4bcbb0ac8ffc364fa9b22da10d3054778d2332f68b365e5e5af8e71541"
-			}
-		],
-		"blockstakeinputs": [
-			{
-				"parentid": "dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfde",
-				"unlocker": {
-					"type": 1,
-					"condition": {
-						"publickey": "ed25519:ef1234ef1234ef1234ef1234ef1234ef1234ef1234ef1234ef1234ef1234ef12"
-					},
-					"fulfillment": {
-						"signature": "01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def"
-					}
+		},
+		{
+			"parentid": "012345defabc012345defabc012345defabc012345defabc012345defabc0123",
+			"unlocker": {
+				"type": 2,
+				"condition": {
+					"sender": "01654f96b317efe5fd6cd8ba1a394dce7b6ebe8c9621d6c44cbe3c8f1b58ce632a3216de71b23b",
+					"receiver": "01e89843e4b8231a01ba18b254d530110364432aafab8206bea72e5a20eaa55f70b1ccc65e2105",
+					"hashedsecret": "abc543defabc543defabc543defabc543defabc543defabc543defabc543defa",
+					"timelock": 1522068743
+				},
+				"fulfillment": {
+					"publickey": "ed25519:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+					"signature": "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefab",
+					"secret": "def789def789def789def789def789dedef789def789def789def789def789de"
 				}
 			}
-		],
-		"blockstakeoutputs": [
-			{
-				"value": "4",
-				"unlockhash": "6453402d094ed0f336950c4be0feec37167aaaaf8b974d265900e49ab22773584cfe96393b1360"
-			},
-			{
-				"value": "2",
-				"unlockhash": "2ab39baa9a58319fa47f78ed542a733a7198d106caeabf0a231b91ea3e4e222ffd8b27c861beff"
+		}
+	],
+	"coinoutputs": [
+		{
+			"value": "3",
+			"unlockhash": "0142e9458e348598111b0bc19bda18e45835605db9f4620616d752220ae8605ce0df815fd7570e"
+		},
+		{
+			"value": "5",
+			"unlockhash": "01a6a6c5584b2bfbd08738996cd7930831f958b9a5ed1595525236e861c1a0dc353bdcf54be7d8"
+		},
+		{
+			"value": "8",
+			"unlockhash": "02a24c97c80eeac111aa4bcbb0ac8ffc364fa9b22da10d3054778d2332f68b365e5e5af8e71541"
+		}
+	],
+	"blockstakeinputs": [
+		{
+			"parentid": "dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfd23dfde",
+			"unlocker": {
+				"type": 1,
+				"condition": {
+					"publickey": "ed25519:ef1234ef1234ef1234ef1234ef1234ef1234ef1234ef1234ef1234ef1234ef12"
+				},
+				"fulfillment": {
+					"signature": "01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def01234def"
+				}
 			}
-		],
-		"minerfees": [
-			"1",
-			"2",
-			"3"
-		],
-		"arbitrarydata": "ZGF0YQ=="
-	}
+		}
+	],
+	"blockstakeoutputs": [
+		{
+			"value": "4",
+			"unlockhash": "6453402d094ed0f336950c4be0feec37167aaaaf8b974d265900e49ab22773584cfe96393b1360"
+		},
+		{
+			"value": "2",
+			"unlockhash": "2ab39baa9a58319fa47f78ed542a733a7198d106caeabf0a231b91ea3e4e222ffd8b27c861beff"
+		}
+	],
+	"minerfees": [
+		"1",
+		"2",
+		"3"
+	],
+	"arbitrarydata": "ZGF0YQ=="
 }`,
 	}
 	for testIndex, testCase := range testCases {
-		var txn legacyTransaction
-		err := json.Unmarshal([]byte(testCase), &txn)
+		var ltd legacyTransactionData
+		err := json.Unmarshal([]byte(testCase), &ltd)
 		if err != nil {
 			t.Error(testIndex, err)
 			continue
@@ -234,7 +228,7 @@ func TestLegacyTransactionJSONEncoding(t *testing.T) {
 		buf := bytes.NewBuffer(nil)
 		encoder := json.NewEncoder(buf)
 		encoder.SetIndent("", "\t")
-		err = encoder.Encode(txn)
+		err = encoder.Encode(ltd)
 		if err != nil {
 			t.Error(testIndex, err)
 			continue
@@ -259,13 +253,12 @@ func TestLegacyTransactionToTransaction(t *testing.T) {
 	}
 
 	testCases := []struct {
-		EncodedTransaction  string
-		ExpectedTransaction Transaction
+		EncodedTransactionData  string
+		ExpectedTransactionData TransactionData
 	}{
 		{
-			`0001000000000000002200000000000000000000000000000000000000000000000000000000000022013800000000000000656432353531390000000000000000002000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff4000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000000000000000000000000000000000000000000000001000000000000000100000000000000010000000000000000`,
-			Transaction{
-				Version: TransactionVersionZero,
+			`01000000000000002200000000000000000000000000000000000000000000000000000000000022013800000000000000656432353531390000000000000000002000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff4000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000000000000000000000000000000000000000000000001000000000000000100000000000000010000000000000000`,
+			TransactionData{
 				CoinInputs: []CoinInput{
 					{
 						ParentID: CoinOutputID(hs("2200000000000000000000000000000000000000000000000000000000000022")),
@@ -282,9 +275,8 @@ func TestLegacyTransactionToTransaction(t *testing.T) {
 			},
 		},
 		{
-			`0002000000000000002200000000000000000000000000000000000000000000000000000000000022013800000000000000656432353531390000000000000000002000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff4000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3300000000000000000000000000000000000000000000000000000000000033026a00000000000000011234567891234567891234567891234567891234567891234567891234567891016363636363636363636363636363636363636363636363636363636363636363bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb07edb85a00000000a000000000000000656432353531390000000000000000002000000000000000abababababababababababababababababababababababababababababababab4000000000000000dededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededabadabadabadabadabadabadabadabadabadabadabadabadabadabadabadaba020000000000000001000000000000000201cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc01000000000000000302dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd01000000000000004400000000000000000000000000000000000000000000000000000000000044013800000000000000656432353531390000000000000000002000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee4000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee010000000000000001000000000000002a01abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd010000000000000001000000000000000102000000000000003432`,
-			Transaction{
-				Version: TransactionVersionZero,
+			`02000000000000002200000000000000000000000000000000000000000000000000000000000022013800000000000000656432353531390000000000000000002000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff4000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3300000000000000000000000000000000000000000000000000000000000033026a00000000000000011234567891234567891234567891234567891234567891234567891234567891016363636363636363636363636363636363636363636363636363636363636363bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb07edb85a00000000a000000000000000656432353531390000000000000000002000000000000000abababababababababababababababababababababababababababababababab4000000000000000dededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededabadabadabadabadabadabadabadabadabadabadabadabadabadabadabadaba020000000000000001000000000000000201cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc01000000000000000302dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd01000000000000004400000000000000000000000000000000000000000000000000000000000044013800000000000000656432353531390000000000000000002000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee4000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee010000000000000001000000000000002a01abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd010000000000000001000000000000000102000000000000003432`,
+			TransactionData{
 				CoinInputs: []CoinInput{
 					{
 						ParentID: CoinOutputID(hs("2200000000000000000000000000000000000000000000000000000000000022")),
@@ -361,22 +353,22 @@ func TestLegacyTransactionToTransaction(t *testing.T) {
 		},
 	}
 	for testIndex, testCase := range testCases {
-		binaryInput, err := hex.DecodeString(testCase.EncodedTransaction)
+		binaryInput, err := hex.DecodeString(testCase.EncodedTransactionData)
 		if err != nil {
 			t.Error(testIndex, err)
 			continue
 		}
 
-		var lt legacyTransaction
-		err = encoding.Unmarshal(binaryInput, &lt)
+		var ltd legacyTransactionData
+		err = encoding.Unmarshal(binaryInput, &ltd)
 		if err != nil {
 			t.Error(testIndex, err)
 			continue
 		}
+		data := ltd.TransactionData()
 
-		txn := lt.Transaction()
-		if !reflect.DeepEqual(testCase.ExpectedTransaction, txn) {
-			t.Error(testIndex, testCase.ExpectedTransaction, "!=", txn)
+		if !reflect.DeepEqual(testCase.ExpectedTransactionData, data) {
+			t.Error(testIndex, testCase.ExpectedTransactionData, "!=", data)
 		}
 	}
 }
@@ -705,10 +697,10 @@ func TestLegacyTransactionSignatures(t *testing.T) {
 	}
 }
 
-func TestLegacyTransactionBiDirectional(t *testing.T) {
+func TestLegacyTransactionDataBiDirectional(t *testing.T) {
 	testCases := []string{
-		`0001000000000000002200000000000000000000000000000000000000000000000000000000000022013800000000000000656432353531390000000000000000002000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff4000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000000000000000000000000000000000000000000000001000000000000000100000000000000010000000000000000`,
-		`0002000000000000002200000000000000000000000000000000000000000000000000000000000022013800000000000000656432353531390000000000000000002000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff4000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3300000000000000000000000000000000000000000000000000000000000033026a00000000000000011234567891234567891234567891234567891234567891234567891234567891016363636363636363636363636363636363636363636363636363636363636363bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb07edb85a00000000a000000000000000656432353531390000000000000000002000000000000000abababababababababababababababababababababababababababababababab4000000000000000dededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededabadabadabadabadabadabadabadabadabadabadabadabadabadabadabadaba020000000000000001000000000000000201cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc01000000000000000302dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd01000000000000004400000000000000000000000000000000000000000000000000000000000044013800000000000000656432353531390000000000000000002000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee4000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee010000000000000001000000000000002a01abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd010000000000000001000000000000000102000000000000003432`,
+		`01000000000000002200000000000000000000000000000000000000000000000000000000000022013800000000000000656432353531390000000000000000002000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff4000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000000000000000000000000000000000000000000000001000000000000000100000000000000010000000000000000`,
+		`02000000000000002200000000000000000000000000000000000000000000000000000000000022013800000000000000656432353531390000000000000000002000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff4000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3300000000000000000000000000000000000000000000000000000000000033026a00000000000000011234567891234567891234567891234567891234567891234567891234567891016363636363636363636363636363636363636363636363636363636363636363bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb07edb85a00000000a000000000000000656432353531390000000000000000002000000000000000abababababababababababababababababababababababababababababababab4000000000000000dededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededabadabadabadabadabadabadabadabadabadabadabadabadabadabadabadaba020000000000000001000000000000000201cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc01000000000000000302dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd01000000000000004400000000000000000000000000000000000000000000000000000000000044013800000000000000656432353531390000000000000000002000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee4000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee010000000000000001000000000000002a01abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd010000000000000001000000000000000102000000000000003432`,
 	}
 	for testIndex, testCase := range testCases {
 		binaryInput, err := hex.DecodeString(testCase)
@@ -717,21 +709,21 @@ func TestLegacyTransactionBiDirectional(t *testing.T) {
 			continue
 		}
 
-		var txn legacyTransaction
-		err = encoding.Unmarshal(binaryInput, &txn)
+		var ltd legacyTransactionData
+		err = encoding.Unmarshal(binaryInput, &ltd)
 		if err != nil {
 			t.Error(testIndex, err)
 			continue
 		}
 
-		otxn, err := newLegacyTransaction(txn.Transaction())
+		oltd, err := newLegacyTransactionData(ltd.TransactionData())
 		if err != nil {
 			t.Error(testIndex, err)
 			continue
 		}
 
-		if !reflect.DeepEqual(txn, otxn) {
-			t.Error(testIndex, txn, "!=", otxn)
+		if !reflect.DeepEqual(ltd, oltd) {
+			t.Error(testIndex, ltd, "!=", oltd)
 		}
 	}
 }

--- a/types/transactions.go
+++ b/types/transactions.go
@@ -357,6 +357,16 @@ var (
 )
 
 // ValidateTransaction validates this transaction in the given context.
+//
+// By default it checks for a transaction whether the transaction fits within a block,
+// that the arbitrary data is within a limited size, there are no outputs
+// spent multiple times, all defined values adhere to a network-constant defined
+// minimum value (e.g. miner fees having to be at least the MinimumMinerFee),
+// and also validates that all used Conditions and Fulfillments are standard.
+//
+// Each transaction Version however can also choose to overwrite this logic,
+// and implement none, some or all of these default rules, optionally
+// adding some version-specific rules to it.
 func (t Transaction) ValidateTransaction(ctx ValidationContext, constants TransactionValidationConstants) error {
 	controller, exists := _RegisteredTransactionVersions[t.Version]
 	if !exists {

--- a/types/transactions_test.go
+++ b/types/transactions_test.go
@@ -1793,18 +1793,17 @@ func TestIDComputationCompatibleWithLegacyIDs(t *testing.T) {
 // ID returns the id of a transaction, which is taken by marshalling all of the
 // fields except for the signatures and taking the hash of the result.
 func (t Transaction) LegacyID() TransactionID {
-	t.Version = TransactionVersionZero // as to avoid a panic
-	lt, err := newLegacyTransaction(t)
+	ltd, err := newLegacyTransactionDataFromTransaction(t)
 	if err != nil {
 		panic(err)
 	}
 	return TransactionID(crypto.HashAll(
-		lt.Data.CoinInputs,
-		lt.Data.CoinOutputs,
-		lt.Data.BlockStakeInputs,
-		lt.Data.BlockStakeOutputs,
-		lt.Data.MinerFees,
-		lt.Data.ArbitraryData,
+		ltd.CoinInputs,
+		ltd.CoinOutputs,
+		ltd.BlockStakeInputs,
+		ltd.BlockStakeOutputs,
+		ltd.MinerFees,
+		ltd.ArbitraryData,
 	))
 }
 
@@ -1813,19 +1812,18 @@ func (t Transaction) LegacyID() TransactionID {
 // Specifier, all of the fields in the transaction (except the signatures),
 // and output index.
 func (t Transaction) LegacyCoinOutputID(i uint64) CoinOutputID {
-	t.Version = TransactionVersionZero // as to avoid a panic
-	lt, err := newLegacyTransaction(t)
+	ltd, err := newLegacyTransactionDataFromTransaction(t)
 	if err != nil {
 		panic(err)
 	}
 	return CoinOutputID(crypto.HashAll(
 		SpecifierCoinOutput,
-		lt.Data.CoinInputs,
-		lt.Data.CoinOutputs,
-		lt.Data.BlockStakeInputs,
-		lt.Data.BlockStakeOutputs,
-		lt.Data.MinerFees,
-		lt.Data.ArbitraryData,
+		ltd.CoinInputs,
+		ltd.CoinOutputs,
+		ltd.BlockStakeInputs,
+		ltd.BlockStakeOutputs,
+		ltd.MinerFees,
+		ltd.ArbitraryData,
 		i,
 	))
 }
@@ -1835,19 +1833,19 @@ func (t Transaction) LegacyCoinOutputID(i uint64) CoinOutputID {
 // all of the fields in the transaction (except the signatures), and output
 // index.
 func (t Transaction) LegacyBlockStakeOutputID(i uint64) BlockStakeOutputID {
-	t.Version = TransactionVersionZero // as to avoid a panic
-	lt, err := newLegacyTransaction(t)
+
+	ltd, err := newLegacyTransactionDataFromTransaction(t)
 	if err != nil {
 		panic(err)
 	}
 	return BlockStakeOutputID(crypto.HashAll(
 		SpecifierBlockStakeOutput,
-		lt.Data.CoinInputs,
-		lt.Data.CoinOutputs,
-		lt.Data.BlockStakeInputs,
-		lt.Data.BlockStakeOutputs,
-		lt.Data.MinerFees,
-		lt.Data.ArbitraryData,
+		ltd.CoinInputs,
+		ltd.CoinOutputs,
+		ltd.BlockStakeInputs,
+		ltd.BlockStakeOutputs,
+		ltd.MinerFees,
+		ltd.ArbitraryData,
 		i,
 	))
 }

--- a/types/unlockcondition.go
+++ b/types/unlockcondition.go
@@ -39,7 +39,7 @@ type (
 		// An error result means it is not standard,
 		// and it will consequently prevent the transaction, which includes the
 		// the output that has this condition, from being minted into a block.
-		IsStandardCondition(StandardCheckContext) error
+		IsStandardCondition(ValidationContext) error
 
 		// UnlockHash returns the deterministic unlock hash of this UnlockCondition.
 		// It identifies the owner(s) or contract which own the output,
@@ -102,7 +102,7 @@ type (
 		// An error result means it is not standard,
 		// and it will consequently prevent the transaction, which includes the
 		// the input that has this fulfillment, from being minted into a block.
-		IsStandardFulfillment(StandardCheckContext) error
+		IsStandardFulfillment(ValidationContext) error
 	}
 	// MarshalableUnlockFulfillment adds binary marshaling as a required interface
 	// to the regular unlock fulfillment interface. This allows the fulfillment
@@ -140,11 +140,17 @@ type (
 		Fulfillment MarshalableUnlockFulfillment
 	}
 
-	// StandardCheckContext is given as part of any IsStandard check,
+	// ValidationContext is given as part of any IsStandard check,
 	// as to give some context in order to present a more informed
-	// conclusion of whether or not a condition/fulfillment is standard.
-	StandardCheckContext struct {
-		// BlockHeight of the currently last registered block.
+	// conclusion of whether or not a condition/fulfillment is standard,
+	// as well as if a transaction is valid on a local level.
+	ValidationContext struct {
+		// Confirmed defines whether or not the (parent) transaction
+		// is already confirmed, or in other words is part of a created block already.
+		Confirmed bool
+		// BlockHeight defines either the height of the block the (parent) transaction is part of,
+		// or it defines the height of the last confirmed/created block.
+		// It's the latter in case Confirmed is false, the first otherwise.
 		BlockHeight BlockHeight
 	}
 
@@ -562,7 +568,7 @@ func (n *NilCondition) Fulfill(fulfillment UnlockFulfillment, ctx FulfillContext
 func (n *NilCondition) ConditionType() ConditionType { return ConditionTypeNil }
 
 // IsStandardCondition implements UnlockCondition.IsStandardCondition
-func (n *NilCondition) IsStandardCondition(StandardCheckContext) error { return nil } // always valid
+func (n *NilCondition) IsStandardCondition(ValidationContext) error { return nil } // always valid
 
 // UnlockHash implements UnlockCondition.UnlockHash
 func (n *NilCondition) UnlockHash() UnlockHash { return NilUnlockHash }
@@ -600,7 +606,7 @@ func (n *NilFulfillment) Equal(f UnlockFulfillment) bool {
 func (n *NilFulfillment) FulfillmentType() FulfillmentType { return FulfillmentTypeNil }
 
 // IsStandardFulfillment implements UnlockFulfillment.IsStandardFulfillment
-func (n *NilFulfillment) IsStandardFulfillment(StandardCheckContext) error {
+func (n *NilFulfillment) IsStandardFulfillment(ValidationContext) error {
 	return ErrNilFulfillmentType
 } // never valid
 
@@ -702,7 +708,7 @@ func (uh *UnlockHashCondition) Fulfill(fulfillment UnlockFulfillment, ctx Fulfil
 func (uh *UnlockHashCondition) ConditionType() ConditionType { return ConditionTypeUnlockHash }
 
 // IsStandardCondition implements UnlockCondition.IsStandardCondition
-func (uh *UnlockHashCondition) IsStandardCondition(StandardCheckContext) error {
+func (uh *UnlockHashCondition) IsStandardCondition(ValidationContext) error {
 	if uh.TargetUnlockHash.Type != UnlockTypePubKey && uh.TargetUnlockHash.Type != UnlockTypeAtomicSwap {
 		return fmt.Errorf("unsupported unlock type '%d' by unlock hash condition", uh.TargetUnlockHash.Type)
 	}
@@ -763,7 +769,7 @@ func (ss *SingleSignatureFulfillment) FulfillmentType() FulfillmentType {
 }
 
 // IsStandardFulfillment implements UnlockFulfillment.IsStandardFulfillment
-func (ss *SingleSignatureFulfillment) IsStandardFulfillment(StandardCheckContext) error {
+func (ss *SingleSignatureFulfillment) IsStandardFulfillment(ValidationContext) error {
 	return strictSignatureCheck(ss.PublicKey, ss.Signature)
 }
 
@@ -877,7 +883,7 @@ func (as *AtomicSwapCondition) Fulfill(fulfillment UnlockFulfillment, ctx Fulfil
 func (as *AtomicSwapCondition) ConditionType() ConditionType { return ConditionTypeAtomicSwap }
 
 // IsStandardCondition implements UnlockCondition.IsStandardCondition
-func (as *AtomicSwapCondition) IsStandardCondition(StandardCheckContext) error {
+func (as *AtomicSwapCondition) IsStandardCondition(ValidationContext) error {
 	if as.Sender.Type != UnlockTypePubKey {
 		return fmt.Errorf("unsupported unlock hash sender type: %d", as.Sender.Type)
 	}
@@ -983,7 +989,7 @@ func (as *AtomicSwapFulfillment) Sign(ctx FulfillmentSignContext) error {
 func (as *AtomicSwapFulfillment) FulfillmentType() FulfillmentType { return FulfillmentTypeAtomicSwap }
 
 // IsStandardFulfillment implements UnlockFulfillment.IsStandardFulfillment
-func (as *AtomicSwapFulfillment) IsStandardFulfillment(StandardCheckContext) error {
+func (as *AtomicSwapFulfillment) IsStandardFulfillment(ValidationContext) error {
 	return strictSignatureCheck(as.PublicKey, as.Signature)
 }
 
@@ -1048,7 +1054,7 @@ func (as *LegacyAtomicSwapFulfillment) FulfillmentType() FulfillmentType {
 }
 
 // IsStandardFulfillment implements UnlockFulfillment.IsStandardFulfillment
-func (as *LegacyAtomicSwapFulfillment) IsStandardFulfillment(StandardCheckContext) error {
+func (as *LegacyAtomicSwapFulfillment) IsStandardFulfillment(ValidationContext) error {
 	if as.Sender.Type != UnlockTypePubKey || as.Receiver.Type != UnlockTypePubKey {
 		return errors.New("unsupported unlock hash type")
 	}
@@ -1325,7 +1331,7 @@ func (tl *TimeLockCondition) Fulfill(fulfillment UnlockFulfillment, ctx FulfillC
 func (tl *TimeLockCondition) ConditionType() ConditionType { return ConditionTypeTimeLock }
 
 // IsStandardCondition implements UnlockCondition.IsStandardCondition
-func (tl *TimeLockCondition) IsStandardCondition(ctx StandardCheckContext) error {
+func (tl *TimeLockCondition) IsStandardCondition(ctx ValidationContext) error {
 	if tl.LockTime == 0 {
 		return errors.New("lock time has to be defined")
 	}
@@ -1508,7 +1514,7 @@ func (ms *MultiSignatureCondition) Fulfill(fulfillment UnlockFulfillment, ctx Fu
 func (ms *MultiSignatureCondition) ConditionType() ConditionType { return ConditionTypeMultiSignature }
 
 // IsStandardCondition implements UnlockCondition.IsStandardCondition
-func (ms *MultiSignatureCondition) IsStandardCondition(StandardCheckContext) error {
+func (ms *MultiSignatureCondition) IsStandardCondition(ValidationContext) error {
 	if ms.MinimumSignatureCount == 0 {
 		return errors.New("A minimum amount of required signatures must be specified")
 	}
@@ -1623,7 +1629,7 @@ func (ms *MultiSignatureFulfillment) FulfillmentType() FulfillmentType {
 }
 
 // IsStandardFulfillment implements UnlockFulfillment.IsStandardFulfillment
-func (ms *MultiSignatureFulfillment) IsStandardFulfillment(StandardCheckContext) error {
+func (ms *MultiSignatureFulfillment) IsStandardFulfillment(ValidationContext) error {
 	if len(ms.Pairs) == 0 {
 		return errors.New("At least one pair must be provided")
 	}
@@ -1766,7 +1772,7 @@ func (up UnlockConditionProxy) ConditionType() ConditionType {
 //
 // If no child is defined, nil will be returned,
 // otherwise the question will be delegated to the child condition.
-func (up UnlockConditionProxy) IsStandardCondition(ctx StandardCheckContext) error {
+func (up UnlockConditionProxy) IsStandardCondition(ctx ValidationContext) error {
 	condition := up.Condition
 	if condition == nil {
 		condition = &NilCondition{}
@@ -1838,7 +1844,7 @@ func (fp UnlockFulfillmentProxy) FulfillmentType() FulfillmentType {
 //
 // If no child is defined, an error will be returned,
 // otherwise the question will be delegated to the child fulfillmment.
-func (fp UnlockFulfillmentProxy) IsStandardFulfillment(ctx StandardCheckContext) error {
+func (fp UnlockFulfillmentProxy) IsStandardFulfillment(ctx ValidationContext) error {
 	fulfillment := fp.Fulfillment
 	if fulfillment == nil {
 		fulfillment = &NilFulfillment{}

--- a/types/unlockcondition.go
+++ b/types/unlockcondition.go
@@ -2152,7 +2152,10 @@ func signHashUsingSiaPublicKey(pk SiaPublicKey, inputIndex uint64, tx Transactio
 		if edSK.IsNil() {
 			return nil, crypto.ErrSecretNilKey
 		}
-		sigHash := tx.InputSigHash(inputIndex, extraObjects...)
+		sigHash, err := tx.InputSigHash(inputIndex, extraObjects...)
+		if err != nil {
+			return nil, err
+		}
 		sig := crypto.SignHash(sigHash, edSK)
 		return sig[:], nil
 
@@ -2184,8 +2187,11 @@ func verifyHashUsingSiaPublicKey(pk SiaPublicKey, inputIndex uint64, tx Transact
 			return crypto.ErrPublicNilKey
 		}
 		cryptoSig := crypto.Signature(edSig)
-		sigHash := tx.InputSigHash(inputIndex, extraObjects...)
-		err = crypto.VerifyHash(sigHash, edPK, cryptoSig)
+		var sigHash crypto.Hash
+		sigHash, err = tx.InputSigHash(inputIndex, extraObjects...)
+		if err == nil {
+			err = crypto.VerifyHash(sigHash, edPK, cryptoSig)
+		}
 
 	default:
 		err = ErrUnknownSignAlgorithmType

--- a/types/unlockcondition_test.go
+++ b/types/unlockcondition_test.go
@@ -1733,13 +1733,16 @@ func TestFulfillLegacyCompatibility(t *testing.T) {
 	}
 	for tidx, testCase := range testCases {
 		for idx, ci := range testCase.Transaction.CoinInputs {
-			sigHash := testCase.Transaction.InputSigHash(uint64(idx))
+			sigHash, err := testCase.Transaction.InputSigHash(uint64(idx))
+			if err != nil {
+				t.Error(tidx, idx, "unexpected error", err)
+			}
 			if bytes.Compare(testCase.ExpectedCoinInputSigHashes[idx][:], sigHash[:]) != 0 {
 				t.Error(tidx, idx, "invalid coin input sigh hash",
 					testCase.ExpectedCoinInputSigHashes[idx], "!=", sigHash)
 			}
 
-			err := ci.Fulfillment.IsStandardFulfillment(ValidationContext{})
+			err = ci.Fulfillment.IsStandardFulfillment(ValidationContext{})
 			if err != nil {
 				t.Error(tidx, idx, "unexpected error", err)
 			}
@@ -1753,13 +1756,16 @@ func TestFulfillLegacyCompatibility(t *testing.T) {
 			}
 		}
 		for idx, bsi := range testCase.Transaction.BlockStakeInputs {
-			sigHash := testCase.Transaction.InputSigHash(uint64(idx))
+			sigHash, err := testCase.Transaction.InputSigHash(uint64(idx))
+			if err != nil {
+				t.Error(tidx, idx, "unexpected error", err)
+			}
 			if bytes.Compare(testCase.ExpectedBlockStakeInputSigHashes[idx][:], sigHash[:]) != 0 {
 				t.Error(tidx, idx, "invalid bs input sigh hash",
 					testCase.ExpectedBlockStakeInputSigHashes[idx], "!=", sigHash)
 			}
 
-			err := bsi.Fulfillment.IsStandardFulfillment(ValidationContext{})
+			err = bsi.Fulfillment.IsStandardFulfillment(ValidationContext{})
 			if err != nil {
 				t.Error(tidx, idx, "unexpected error", err)
 			}

--- a/types/unlockcondition_test.go
+++ b/types/unlockcondition_test.go
@@ -384,7 +384,7 @@ func TestNilUnlockConditionProxy(t *testing.T) {
 	if ct := c.ConditionType(); ct != ConditionTypeNil {
 		t.Error("ConditionType", ct, "!=", ConditionTypeNil)
 	}
-	if err := c.IsStandardCondition(StandardCheckContext{}); err != nil {
+	if err := c.IsStandardCondition(ValidationContext{}); err != nil {
 		t.Error("IsStandardCondition", err)
 	}
 	if b, err := c.MarshalJSON(); err != nil || string(b) != "{}" {
@@ -409,7 +409,7 @@ func TestNilUnlockFulfillmentProxy(t *testing.T) {
 	if ft := f.FulfillmentType(); ft != FulfillmentTypeNil {
 		t.Error("FulfillmentType", ft, "!=", FulfillmentTypeNil)
 	}
-	if err := f.IsStandardFulfillment(StandardCheckContext{}); err == nil {
+	if err := f.IsStandardFulfillment(ValidationContext{}); err == nil {
 		t.Error("IsStandardFulfillment should not be standard")
 	}
 	if b, err := f.MarshalJSON(); err != nil || string(b) != "{}" {
@@ -1739,7 +1739,7 @@ func TestFulfillLegacyCompatibility(t *testing.T) {
 					testCase.ExpectedCoinInputSigHashes[idx], "!=", sigHash)
 			}
 
-			err := ci.Fulfillment.IsStandardFulfillment(StandardCheckContext{})
+			err := ci.Fulfillment.IsStandardFulfillment(ValidationContext{})
 			if err != nil {
 				t.Error(tidx, idx, "unexpected error", err)
 			}
@@ -1759,7 +1759,7 @@ func TestFulfillLegacyCompatibility(t *testing.T) {
 					testCase.ExpectedBlockStakeInputSigHashes[idx], "!=", sigHash)
 			}
 
-			err := bsi.Fulfillment.IsStandardFulfillment(StandardCheckContext{})
+			err := bsi.Fulfillment.IsStandardFulfillment(ValidationContext{})
 			if err != nil {
 				t.Error(tidx, idx, "unexpected error", err)
 			}
@@ -1778,7 +1778,7 @@ func TestFulfillLegacyCompatibility(t *testing.T) {
 				t.Error(tidx, idx, testCase.ExpectedCoinIdentifiers[idx], "!=", outputID)
 			}
 
-			err := co.Condition.IsStandardCondition(StandardCheckContext{})
+			err := co.Condition.IsStandardCondition(ValidationContext{})
 			if err != nil {
 				t.Error(tidx, idx, "unexpected error", err)
 			}
@@ -1789,7 +1789,7 @@ func TestFulfillLegacyCompatibility(t *testing.T) {
 				t.Error(tidx, idx, testCase.ExpectedBlockStakeIdentifiers[idx], "!=", outputID)
 			}
 
-			err := bso.Condition.IsStandardCondition(StandardCheckContext{})
+			err := bso.Condition.IsStandardCondition(ValidationContext{})
 			if err != nil {
 				t.Error(tidx, idx, "unexpected error", err)
 			}
@@ -2307,7 +2307,7 @@ func TestIsStandardCondition(t *testing.T) {
 		},
 	}
 	for idx, testCase := range testCases {
-		err := testCase.Condition.IsStandardCondition(StandardCheckContext{})
+		err := testCase.Condition.IsStandardCondition(ValidationContext{})
 		if testCase.NotStandardMessage != "" {
 			if err == nil {
 				t.Error(idx, "expected error, but none received:", testCase.NotStandardMessage, testCase.Condition)
@@ -2841,7 +2841,7 @@ func TestIsStandardFulfillment(t *testing.T) {
 		},
 	}
 	for idx, testCase := range testCases {
-		err := testCase.Fulfillment.IsStandardFulfillment(StandardCheckContext{})
+		err := testCase.Fulfillment.IsStandardFulfillment(ValidationContext{})
 		if testCase.NotStandardMessage != "" {
 			if err == nil {
 				t.Error(idx, "expected error, but none received:", testCase.NotStandardMessage, testCase.Fulfillment)

--- a/types/validtransaction.go
+++ b/types/validtransaction.go
@@ -15,15 +15,15 @@ var (
 	ErrDoubleSpend           = errors.New("transaction uses a parent object twice")
 	ErrNonZeroRevision       = errors.New("new file contract has a nonzero revision number")
 	ErrTransactionTooLarge   = errors.New("transaction is too large to fit in a block")
-	ErrZeroMinerFee          = errors.New("transaction has a zero value miner fee")
+	ErrTooSmallMinerFee      = errors.New("transaction has a too small miner fee")
 	ErrZeroOutput            = errors.New("transaction cannot have an output or payout that has zero value")
 	ErrArbitraryDataTooLarge = errors.New("arbitrary data is too large to fit in a transaction")
 )
 
-// fitsInABlock checks if the transaction is likely to fit in a block.
+// TransactionFitsInABlock checks if the transaction is likely to fit in a block.
 // Currently there is no limitation on transaction size other than it must fit
 // in a block.
-func (t Transaction) fitsInABlock(blockSizeLimit uint64) error {
+func TransactionFitsInABlock(t Transaction, blockSizeLimit uint64) error {
 	// Check that the transaction will fit inside of a block, leaving 5kb for
 	// overhead.
 	if uint64(len(encoding.Marshal(t))) > blockSizeLimit-5e3 {
@@ -32,9 +32,9 @@ func (t Transaction) fitsInABlock(blockSizeLimit uint64) error {
 	return nil
 }
 
-// followsMinimumValues checks that all outputs adhere to the rules for the
-// minimum allowed value (generally 1).
-func (t Transaction) followsMinimumValues() error {
+// TransactionFollowsMinimumValues checks that all outputs adhere to the rules for the
+// minimum allowed values
+func TransactionFollowsMinimumValues(t Transaction, minimumMinerFee Currency) error {
 	for _, sco := range t.CoinOutputs {
 		if sco.Value.IsZero() {
 			return ErrZeroOutput
@@ -46,20 +46,20 @@ func (t Transaction) followsMinimumValues() error {
 		}
 	}
 	for _, fee := range t.MinerFees {
-		if fee.IsZero() {
-			return ErrZeroMinerFee
+		if fee.Cmp(minimumMinerFee) == -1 {
+			return ErrTooSmallMinerFee
 		}
 	}
 	return nil
 }
 
-// noRepeats checks that a transaction does not spend multiple outputs twice,
+// NoRepeatsInTransaction checks that a transaction does not spend multiple outputs twice,
 // submit two valid storage proofs for the same file contract, etc. We
 // frivolously check that a file contract termination and storage proof don't
 // act on the same file contract. There is very little overhead for doing so,
 // and the check is only frivolous because of the current rule that file
 // contract terminations are not valid after the proof window opens.
-func (t Transaction) noRepeats() error {
+func NoRepeatsInTransaction(t Transaction) error {
 	// Check that there are no repeat instances of coin outputs, storage
 	// proofs, contract terminations, or siafund outputs.
 	coinInputs := make(map[CoinOutputID]struct{})
@@ -81,29 +81,88 @@ func (t Transaction) noRepeats() error {
 	return nil
 }
 
-func (t Transaction) arbitraryDataFits(sizeLimit uint64) error {
-	if uint64(len(t.ArbitraryData)) > sizeLimit {
+// ArbitraryDataFits checks if an arbtirary data first within a given size limit.
+func ArbitraryDataFits(arbitraryData []byte, sizeLimit uint64) error {
+	if uint64(len(arbitraryData)) > sizeLimit {
 		return ErrArbitraryDataTooLarge
 	}
 	return nil
 }
 
-func defaultTransactionValidation(t Transaction, blockSizeLimit, arbitraryDataSizeLimit uint64) (err error) {
-	err = t.fitsInABlock(blockSizeLimit)
+// ValidateNoDoubleSpendsWithinTransaction validates that no output has been spend twice,
+// within the given transaction. NOTE that this is a local test only,
+// and does not guarantee that an output isn't already spend in another transaction.
+func ValidateNoDoubleSpendsWithinTransaction(t Transaction) (err error) {
+	spendCoins := make(map[CoinOutputID]struct{})
+	for _, ci := range t.CoinInputs {
+		if _, found := spendCoins[ci.ParentID]; found {
+			err = ErrDoubleSpend
+			return
+		}
+		spendCoins[ci.ParentID] = struct{}{}
+	}
+
+	spendBlockStakes := make(map[BlockStakeOutputID]struct{})
+	for _, bsi := range t.BlockStakeInputs {
+		if _, found := spendBlockStakes[bsi.ParentID]; found {
+			err = ErrDoubleSpend
+			return
+		}
+		spendBlockStakes[bsi.ParentID] = struct{}{}
+	}
+
+	return
+}
+
+// DefaultTransactionValidation contains the default transaction validation logic,
+// ensuring that within
+func DefaultTransactionValidation(t Transaction, ctx ValidationContext, constants TransactionValidationConstants) (err error) {
+	err = TransactionFitsInABlock(t, constants.BlockSizeLimit)
 	if err != nil {
 		return
 	}
-	err = t.arbitraryDataFits(arbitraryDataSizeLimit)
+	err = ArbitraryDataFits(t.ArbitraryData, constants.ArbitraryDataSizeLimit)
 	if err != nil {
 		return
 	}
-	err = t.noRepeats()
+	err = NoRepeatsInTransaction(t)
 	if err != nil {
 		return
 	}
-	err = t.followsMinimumValues()
+	err = TransactionFollowsMinimumValues(t, constants.MinimumMinerFee)
 	if err != nil {
 		return
 	}
-	return t.validateNoDoubleSpends()
+	err = ValidateNoDoubleSpendsWithinTransaction(t)
+	if err != nil {
+		return
+	}
+	// check if all condtions are standard
+	for _, sco := range t.CoinOutputs {
+		err = sco.Condition.IsStandardCondition(ctx)
+		if err != nil {
+			return err
+		}
+	}
+	for _, sfo := range t.BlockStakeOutputs {
+		err = sfo.Condition.IsStandardCondition(ctx)
+		if err != nil {
+			return err
+		}
+	}
+	// check if all fulfillments are standard
+	for _, sci := range t.CoinInputs {
+		err = sci.Fulfillment.IsStandardFulfillment(ctx)
+		if err != nil {
+			return err
+		}
+	}
+	for _, sfi := range t.BlockStakeInputs {
+		err = sfi.Fulfillment.IsStandardFulfillment(ctx)
+		if err != nil {
+			return err
+		}
+	}
+	// transaction is valid, according to this local check
+	return nil
 }

--- a/types/validtransaction_test.go
+++ b/types/validtransaction_test.go
@@ -12,13 +12,13 @@ func TestTransactionFitsInABlock_V0(t *testing.T) {
 	txn := Transaction{
 		Version:       TransactionVersionZero,
 		ArbitraryData: data}
-	err := txn.fitsInABlock(blockSizeLimit)
+	err := TransactionFitsInABlock(txn, blockSizeLimit)
 	if err != nil {
 		t.Error(err)
 	}
 	data = make([]byte, blockSizeLimit)
 	txn.ArbitraryData = data
-	err = txn.fitsInABlock(blockSizeLimit)
+	err = TransactionFitsInABlock(txn, blockSizeLimit)
 	if err != ErrTransactionTooLarge {
 		t.Error(err)
 	}
@@ -32,13 +32,13 @@ func TestTransactionFitsInABlock_Vd(t *testing.T) {
 	txn := Transaction{
 		Version:       DefaultChainConstants().DefaultTransactionVersion,
 		ArbitraryData: data}
-	err := txn.fitsInABlock(blockSizeLimit)
+	err := TransactionFitsInABlock(txn, blockSizeLimit)
 	if err != nil {
 		t.Error(err)
 	}
 	data = make([]byte, blockSizeLimit)
 	txn.ArbitraryData = data
-	err = txn.fitsInABlock(blockSizeLimit)
+	err = TransactionFitsInABlock(txn, blockSizeLimit)
 	if err != ErrTransactionTooLarge {
 		t.Error(err)
 	}
@@ -54,27 +54,27 @@ func TestTransactionFollowsMinimumValues_V0(t *testing.T) {
 		BlockStakeOutputs: []BlockStakeOutput{{Value: NewCurrency64(1)}},
 		MinerFees:         []Currency{NewCurrency64(1)},
 	}
-	err := txn.followsMinimumValues()
+	err := TransactionFollowsMinimumValues(txn, NewCurrency64(1))
 	if err != nil {
 		t.Error(err)
 	}
 
 	// Try a zero value for each type.
 	txn.CoinOutputs[0].Value = ZeroCurrency
-	err = txn.followsMinimumValues()
+	err = TransactionFollowsMinimumValues(txn, NewCurrency64(1))
 	if err != ErrZeroOutput {
 		t.Error(err)
 	}
 	txn.CoinOutputs[0].Value = NewCurrency64(1)
 	txn.BlockStakeOutputs[0].Value = ZeroCurrency
-	err = txn.followsMinimumValues()
+	err = TransactionFollowsMinimumValues(txn, NewCurrency64(1))
 	if err != ErrZeroOutput {
 		t.Error(err)
 	}
 	txn.BlockStakeOutputs[0].Value = NewCurrency64(1)
 	txn.MinerFees[0] = ZeroCurrency
-	err = txn.followsMinimumValues()
-	if err != ErrZeroMinerFee {
+	err = TransactionFollowsMinimumValues(txn, NewCurrency64(1))
+	if err != ErrTooSmallMinerFee {
 		t.Error(err)
 	}
 	txn.MinerFees[0] = NewCurrency64(1)
@@ -90,27 +90,27 @@ func TestTransactionFollowsMinimumValues_Vd(t *testing.T) {
 		BlockStakeOutputs: []BlockStakeOutput{{Value: NewCurrency64(1)}},
 		MinerFees:         []Currency{NewCurrency64(1)},
 	}
-	err := txn.followsMinimumValues()
+	err := TransactionFollowsMinimumValues(txn, NewCurrency64(1))
 	if err != nil {
 		t.Error(err)
 	}
 
 	// Try a zero value for each type.
 	txn.CoinOutputs[0].Value = ZeroCurrency
-	err = txn.followsMinimumValues()
+	err = TransactionFollowsMinimumValues(txn, NewCurrency64(1))
 	if err != ErrZeroOutput {
 		t.Error(err)
 	}
 	txn.CoinOutputs[0].Value = NewCurrency64(1)
 	txn.BlockStakeOutputs[0].Value = ZeroCurrency
-	err = txn.followsMinimumValues()
+	err = TransactionFollowsMinimumValues(txn, NewCurrency64(1))
 	if err != ErrZeroOutput {
 		t.Error(err)
 	}
 	txn.BlockStakeOutputs[0].Value = NewCurrency64(1)
 	txn.MinerFees[0] = ZeroCurrency
-	err = txn.followsMinimumValues()
-	if err != ErrZeroMinerFee {
+	err = TransactionFollowsMinimumValues(txn, NewCurrency64(1))
+	if err != ErrTooSmallMinerFee {
 		t.Error(err)
 	}
 	txn.MinerFees[0] = NewCurrency64(1)
@@ -128,7 +128,7 @@ func TestTransactionNoRepeats_V0(t *testing.T) {
 
 	// Try a transaction double spending a siacoin output.
 	txn.CoinInputs = append(txn.CoinInputs, CoinInput{})
-	err := txn.noRepeats()
+	err := NoRepeatsInTransaction(txn)
 	if err != ErrDoubleSpend {
 		t.Error(err)
 	}
@@ -136,7 +136,7 @@ func TestTransactionNoRepeats_V0(t *testing.T) {
 
 	// Try a transaction double spending a siafund output.
 	txn.BlockStakeInputs = append(txn.BlockStakeInputs, BlockStakeInput{})
-	err = txn.noRepeats()
+	err = NoRepeatsInTransaction(txn)
 	if err != ErrDoubleSpend {
 		t.Error(err)
 	}
@@ -155,7 +155,7 @@ func TestTransactionNoRepeats_Vd(t *testing.T) {
 
 	// Try a transaction double spending a siacoin output.
 	txn.CoinInputs = append(txn.CoinInputs, CoinInput{})
-	err := txn.noRepeats()
+	err := NoRepeatsInTransaction(txn)
 	if err != ErrDoubleSpend {
 		t.Error(err)
 	}
@@ -163,7 +163,7 @@ func TestTransactionNoRepeats_Vd(t *testing.T) {
 
 	// Try a transaction double spending a siafund output.
 	txn.BlockStakeInputs = append(txn.BlockStakeInputs, BlockStakeInput{})
-	err = txn.noRepeats()
+	err = NoRepeatsInTransaction(txn)
 	if err != ErrDoubleSpend {
 		t.Error(err)
 	}
@@ -174,7 +174,7 @@ func TestTransactionArbitraryDataFits_Vd(t *testing.T) {
 	txn := Transaction{
 		ArbitraryData: []byte{4, 2},
 	}
-	err := txn.arbitraryDataFits(1)
+	err := ArbitraryDataFits(txn.ArbitraryData, 1)
 	if err != ErrArbitraryDataTooLarge {
 		t.Fatal("expected ErrArbitraryDataTooLarge, but received: ", err)
 	}
@@ -188,11 +188,14 @@ func TestUnknownTransactionValidation(t *testing.T) {
 
 	// validation of unknown transactions should always succeed,
 	// as no validation is applied here
-	err := txn.ValidateTransaction(cts.BlockSizeLimit, cts.ArbitraryDataSizeLimit)
+	err := txn.ValidateTransaction(ValidationContext{}, TransactionValidationConstants{
+		BlockSizeLimit:         cts.BlockSizeLimit,
+		ArbitraryDataSizeLimit: cts.ArbitraryDataSizeLimit,
+	})
 	if err != nil {
 		t.Errorf("expected no error, but received: %v", err)
 	}
-	err = txn.ValidateTransaction(0, 0)
+	err = txn.ValidateTransaction(ValidationContext{}, TransactionValidationConstants{})
 	if err != nil {
 		t.Errorf("expected no error, but received: %v", err)
 	}
@@ -205,7 +208,10 @@ func TestLegacyTransactionValidation(t *testing.T) {
 
 	// Build a working transaction.
 	var txn Transaction
-	err := txn.ValidateTransaction(cts.BlockSizeLimit, cts.ArbitraryDataSizeLimit)
+	err := txn.ValidateTransaction(ValidationContext{}, TransactionValidationConstants{
+		BlockSizeLimit:         cts.BlockSizeLimit,
+		ArbitraryDataSizeLimit: cts.ArbitraryDataSizeLimit,
+	})
 	if err != nil {
 		t.Error(err)
 	}
@@ -213,28 +219,40 @@ func TestLegacyTransactionValidation(t *testing.T) {
 	// Violate fitsInABlock.
 	data := make([]byte, cts.BlockSizeLimit)
 	txn.ArbitraryData = data
-	err = txn.ValidateTransaction(cts.BlockSizeLimit, cts.ArbitraryDataSizeLimit)
+	err = txn.ValidateTransaction(ValidationContext{}, TransactionValidationConstants{
+		BlockSizeLimit:         cts.BlockSizeLimit,
+		ArbitraryDataSizeLimit: cts.ArbitraryDataSizeLimit,
+	})
 	if err == nil {
 		t.Error("failed to trigger fitsInABlock error")
 	}
 	// Violate arbitraryDataFits
 	data = make([]byte, cts.ArbitraryDataSizeLimit+1)
 	txn.ArbitraryData = data
-	err = txn.ValidateTransaction(cts.BlockSizeLimit, cts.ArbitraryDataSizeLimit)
+	err = txn.ValidateTransaction(ValidationContext{}, TransactionValidationConstants{
+		BlockSizeLimit:         cts.BlockSizeLimit,
+		ArbitraryDataSizeLimit: cts.ArbitraryDataSizeLimit,
+	})
 	if err == nil {
 		t.Error("failed to trigger arbitraryDataFits error")
 	}
 	txn.ArbitraryData = nil
 
 	// ensure we still validate just fine
-	err = txn.ValidateTransaction(cts.BlockSizeLimit, cts.ArbitraryDataSizeLimit)
+	err = txn.ValidateTransaction(ValidationContext{}, TransactionValidationConstants{
+		BlockSizeLimit:         cts.BlockSizeLimit,
+		ArbitraryDataSizeLimit: cts.ArbitraryDataSizeLimit,
+	})
 	if err != nil {
 		t.Error(err)
 	}
 
 	// Violate noRepeats
 	txn.CoinInputs = []CoinInput{{}, {}}
-	err = txn.ValidateTransaction(cts.BlockSizeLimit, cts.ArbitraryDataSizeLimit)
+	err = txn.ValidateTransaction(ValidationContext{}, TransactionValidationConstants{
+		BlockSizeLimit:         cts.BlockSizeLimit,
+		ArbitraryDataSizeLimit: cts.ArbitraryDataSizeLimit,
+	})
 	if err == nil {
 		t.Error("failed to trigger noRepeats error")
 	}
@@ -242,7 +260,10 @@ func TestLegacyTransactionValidation(t *testing.T) {
 
 	// Violate followsMinimumValues
 	txn.CoinOutputs = []CoinOutput{{}}
-	err = txn.ValidateTransaction(cts.BlockSizeLimit, cts.ArbitraryDataSizeLimit)
+	err = txn.ValidateTransaction(ValidationContext{}, TransactionValidationConstants{
+		BlockSizeLimit:         cts.BlockSizeLimit,
+		ArbitraryDataSizeLimit: cts.ArbitraryDataSizeLimit,
+	})
 	if err == nil {
 		t.Error("failed to trigger followsMinimumValues error")
 	}

--- a/types/validtransaction_test.go
+++ b/types/validtransaction_test.go
@@ -80,8 +80,8 @@ func TestTransactionFollowsMinimumValues_V0(t *testing.T) {
 	txn.MinerFees[0] = NewCurrency64(1)
 }
 
-// TestTransactionFollowsMinimumValues_Vd probes the followsMinimumValues method
-// of the Transaction type.
+// TestTransactionFollowsMinimumValues_Vd probes the
+// TransactionFollowsMinimumValues function
 func TestTransactionFollowsMinimumValues_Vd(t *testing.T) {
 	// Start with a transaction that follows all of minimum-values rules.
 	txn := Transaction{
@@ -116,9 +116,9 @@ func TestTransactionFollowsMinimumValues_Vd(t *testing.T) {
 	txn.MinerFees[0] = NewCurrency64(1)
 }
 
-// TestTransactionNoRepeats_V0 probes the noRepeats method of the Transaction
-// type.
-func TestTransactionNoRepeats_V0(t *testing.T) {
+// TestValidateNoDoubleSpendsWithinTransaction_V0 probes
+// TransactionFollowsMinimumValues function
+func TestValidateNoDoubleSpendsWithinTransaction_V0(t *testing.T) {
 	// Try a transaction all the repeatable types but no conflicts.
 	txn := Transaction{
 		Version:          TransactionVersionZero,
@@ -128,7 +128,7 @@ func TestTransactionNoRepeats_V0(t *testing.T) {
 
 	// Try a transaction double spending a siacoin output.
 	txn.CoinInputs = append(txn.CoinInputs, CoinInput{})
-	err := NoRepeatsInTransaction(txn)
+	err := ValidateNoDoubleSpendsWithinTransaction(txn)
 	if err != ErrDoubleSpend {
 		t.Error(err)
 	}
@@ -136,16 +136,16 @@ func TestTransactionNoRepeats_V0(t *testing.T) {
 
 	// Try a transaction double spending a siafund output.
 	txn.BlockStakeInputs = append(txn.BlockStakeInputs, BlockStakeInput{})
-	err = NoRepeatsInTransaction(txn)
+	err = ValidateNoDoubleSpendsWithinTransaction(txn)
 	if err != ErrDoubleSpend {
 		t.Error(err)
 	}
 	txn.BlockStakeInputs = txn.BlockStakeInputs[:1]
 }
 
-// TestTransactionNoRepeats_Vd probes the noRepeats method of the Transaction
-// type.
-func TestTransactionNoRepeats_Vd(t *testing.T) {
+// TestValidateNoDoubleSpendsWithinTransaction_Vd probes the
+// ValidateNoDoubleSpendsWithinTransaction function
+func TestValidateNoDoubleSpendsWithinTransaction_Vd(t *testing.T) {
 	// Try a transaction all the repeatable types but no conflicts.
 	txn := Transaction{
 		Version:          DefaultChainConstants().DefaultTransactionVersion,
@@ -155,7 +155,7 @@ func TestTransactionNoRepeats_Vd(t *testing.T) {
 
 	// Try a transaction double spending a siacoin output.
 	txn.CoinInputs = append(txn.CoinInputs, CoinInput{})
-	err := NoRepeatsInTransaction(txn)
+	err := ValidateNoDoubleSpendsWithinTransaction(txn)
 	if err != ErrDoubleSpend {
 		t.Error(err)
 	}
@@ -163,7 +163,7 @@ func TestTransactionNoRepeats_Vd(t *testing.T) {
 
 	// Try a transaction double spending a siafund output.
 	txn.BlockStakeInputs = append(txn.BlockStakeInputs, BlockStakeInput{})
-	err = NoRepeatsInTransaction(txn)
+	err = ValidateNoDoubleSpendsWithinTransaction(txn)
 	if err != ErrDoubleSpend {
 		t.Error(err)
 	}


### PR DESCRIPTION
+ Legacy Transactions (v0) can now be overwritten/unregistered,
  just like any other transaction;
   => This is a pure Golang-API change, nothing in the protocol or encoded format changed (proven by unchanged tests such as https://github.com/rivine/rivine/blob/111d9d3e2e72ba9c88a368913b13072d2e5ec386/types/transactions_test.go#L156);
  + as a design consequence, TransactionControllers now can choose completely how to marshal the transaction data in binary format. It's up to the implementation to define if the length if to be prefixed or not. Even though it might be recommended, it is not enforced any longer;
+ The standard check of conditions and fulfillment is now applied in both consensus set,
  and in the transaction pool, rather than the latter alone (fixes #393);
+ Transaction pool and consensus set now both guarantee, at all times,
  that each transaction contains at least a minimum TransactionFee for v0/v1 transactions
  (can be changed, but this is the default behavior) (fixes #389);