### PR TITLE
Fix #286: reboroadcast txns

### DIFF
--- a/modules/transactionpool.go
+++ b/modules/transactionpool.go
@@ -37,6 +37,16 @@ var (
 	TransactionPoolDir = "transactionpool"
 )
 
+const (
+	// TransactionPoolRebroadcastDelay is the amount of blocks we wait for a
+	// transaction in the transaction pool to be broadcasted again, if it is not
+	// included in a block by then.
+	TransactionPoolRebroadcastDelay = 3
+	// TransactionPoolMaxRebroadcasts is the maximum amount of times a transaction
+	// will get broadcast again.
+	TransactionPoolMaxRebroadcasts = 4
+)
+
 // A TransactionPoolSubscriber receives updates about the confirmed and
 // unconfirmed set from the transaction pool. Generally, there is no need to
 // subscribe to both the consensus set and the transaction pool.

--- a/modules/transactionpool/accept.go
+++ b/modules/transactionpool/accept.go
@@ -236,6 +236,8 @@ func (tp *TransactionPool) acceptTransactionSet(ts []types.Transaction) error {
 	for _, oid := range oids {
 		tp.knownObjects[oid] = setID
 	}
+	// remember when the transaction was added
+	tp.broadcastCache[setID] = tp.consensusSet.Height()
 	tp.transactionSetDiffs[setID] = cc
 	tp.transactionListSize += len(encoding.Marshal(ts))
 	return nil

--- a/modules/transactionpool/accept.go
+++ b/modules/transactionpool/accept.go
@@ -237,7 +237,7 @@ func (tp *TransactionPool) acceptTransactionSet(ts []types.Transaction) error {
 		tp.knownObjects[oid] = setID
 	}
 	// remember when the transaction was added
-	tp.broadcastCache[setID] = tp.consensusSet.Height()
+	tp.broadcastCache.add(setID, tp.consensusSet.Height())
 	tp.transactionSetDiffs[setID] = cc
 	tp.transactionListSize += len(encoding.Marshal(ts))
 	return nil

--- a/modules/transactionpool/transactioncache.go
+++ b/modules/transactionpool/transactioncache.go
@@ -1,0 +1,65 @@
+package transactionpool
+
+import (
+	"github.com/rivine/rivine/modules"
+	"github.com/rivine/rivine/types"
+)
+
+type (
+	transactionCache struct {
+		cache map[TransactionSetID]*broadcastInfo
+	}
+
+	broadcastInfo struct {
+		// originalSubmit is the original block height in which a transacton was submitted
+		// in our cache
+		originalSubmit types.BlockHeight
+		// broadcasts is the amount of times we have rebroadcast a transaction
+		broadcasts uint32
+	}
+)
+
+func newTransactionCache() transactionCache {
+	return transactionCache{
+		cache: make(map[TransactionSetID]*broadcastInfo),
+	}
+}
+
+// add a new transaction ID to the cache
+func (tc *transactionCache) add(id TransactionSetID, currentHeight types.BlockHeight) {
+	// Because the update method of the transaction pool purges the tp, and then adds all the
+	// transactions again which it finds are still unconfirmed, we need to check if the id we
+	// add is not already known to us
+	if _, exists := tc.cache[id]; !exists {
+		tc.cache[id] = &broadcastInfo{originalSubmit: currentHeight, broadcasts: 0}
+	}
+}
+
+// delete ensures the transaction ID is no longer present in the cache. If it is not present in the first place,
+// no action is taken.
+func (tc *transactionCache) delete(id TransactionSetID) {
+	if _, exists := tc.cache[id]; exists {
+		delete(tc.cache, id)
+	}
+}
+
+func (tc *transactionCache) getTransactionsToBroadcast(height types.BlockHeight) []TransactionSetID {
+	txnIDs := []TransactionSetID{}
+	for id, info := range tc.cache {
+		if info.shouldRebroadcast(height) {
+			txnIDs = append(txnIDs, id)
+		}
+	}
+	return txnIDs
+}
+
+// shouldRebroadcast decides if the txninfo indicates that the transaction should
+// be rebroadcast. If this should be the case, the broadcasts coutner will be updated.
+func (bci *broadcastInfo) shouldRebroadcast(height types.BlockHeight) bool {
+	if (height-bci.originalSubmit)%modules.TransactionPoolRebroadcastDelay == 0 &&
+		bci.broadcasts <= modules.TransactionPoolMaxRebroadcasts {
+		bci.broadcasts++
+		return true
+	}
+	return false
+}

--- a/modules/transactionpool/transactionpool.go
+++ b/modules/transactionpool/transactionpool.go
@@ -68,6 +68,11 @@ type (
 		// subscriber.
 		subscribers []modules.TransactionPoolSubscriber
 
+		// broadcastCache keeps track of all transaction sets currently in the pool,
+		// and the height at which they were added. For every BROADCAST_DELAY blocks
+		// they are not in the pool, broadcast again.
+		broadcastCache map[TransactionSetID]types.BlockHeight
+
 		// Utilities.
 		db         *persist.BoltDatabase
 		mu         demotemutex.DemoteMutex
@@ -96,6 +101,8 @@ func New(cs modules.ConsensusSet, g modules.Gateway, persistDir string, bcInfo t
 		knownObjects:        make(map[ObjectID]TransactionSetID),
 		transactionSets:     make(map[TransactionSetID][]types.Transaction),
 		transactionSetDiffs: make(map[TransactionSetID]modules.ConsensusChange),
+
+		broadcastCache: make(map[TransactionSetID]types.BlockHeight),
 
 		persistDir: persistDir,
 

--- a/modules/transactionpool/transactionpool.go
+++ b/modules/transactionpool/transactionpool.go
@@ -68,10 +68,8 @@ type (
 		// subscriber.
 		subscribers []modules.TransactionPoolSubscriber
 
-		// broadcastCache keeps track of all transaction sets currently in the pool,
-		// and the height at which they were added. For every BROADCAST_DELAY blocks
-		// they are not in the pool, broadcast again.
-		broadcastCache map[TransactionSetID]types.BlockHeight
+		// broadcastCache keeps track of all transaction sets currently in the pool.
+		broadcastCache transactionCache
 
 		// Utilities.
 		db         *persist.BoltDatabase
@@ -102,7 +100,7 @@ func New(cs modules.ConsensusSet, g modules.Gateway, persistDir string, bcInfo t
 		transactionSets:     make(map[TransactionSetID][]types.Transaction),
 		transactionSetDiffs: make(map[TransactionSetID]modules.ConsensusChange),
 
-		broadcastCache: make(map[TransactionSetID]types.BlockHeight),
+		broadcastCache: newTransactionCache(),
 
 		persistDir: persistDir,
 


### PR DESCRIPTION
Rebroadcast a transaction if it is stuck in the pool. A transaction is considered stuck if a new block is accepted in consensus, and the txn itself is not approved in said block. To avoid spamming the network, we broadcast a transaction only a limited number of times, and only every few blocks. Right now, we rebroadcast 4 times (thus 5 total broadcasts if we also count the original broadcast), and broadcast once every 3 blocks. We also only broadcast if the consensus indicates we are currently synced, to avoid spamming a txn in rapid succession to the network if the deamon is syncing (as we can't know if the txn is still valid anyway).

The pool does not "propagate" a rebroadcast, to avoid too much network spam. There is also no benefit: for a pool to REbroadcast, it would already need to have a copy of the txn. Therefore this pool will trigger the rebroadcast by itself a couple of times (it is possible that there is a difference of blocks at which the rebroadcast occurs, though this is not an issue).